### PR TITLE
report-replayed: allow varying aggregation parameter.

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -939,12 +939,12 @@ The validation checks are as follows.
    is marked as invalid with the error `batch-collected`. This prevents
    additional reports from being aggregated after its batch has already
    been collected.
-2. Check if the report has already been aggregated. If this check fails,
-   the input share is marked as invalid with the error `report-replayed`.
-   This is the case if the report was used in a previous aggregate request
-   and is therefore a replay. An aggregator may also choose to mark an
-   input share as invalid with the  error `report-dropped` under the conditions
-   prescribed in {{anti-replay}}.
+2. Check if the report has already been aggregated with this aggregation
+   parameter. If this check fails, the input share is marked as invalid with
+   the error `report-replayed`. This is the case if the report was used in a
+   previous aggregate request and is therefore a replay. An aggregator may also
+   choose to mark an input share as invalid with the  error `report-dropped`
+   under the conditions prescribed in {{anti-replay}}.
 
 If both checks succeed, the input share is not marked as invalid.
 


### PR DESCRIPTION
Previously, report-replayed would be returned if the same client report
was aggregated more than once. However, some VDAFs (e.g. poplar1) will
require repeatedly aggregating a given client report with varying
aggregation parameters. This commit relaxes the condition on which
report-replayed will be returned to allow aggregating the same client
report multiple times, as long as each aggregation has a distinct
aggregation parameter.

Closes #283.