### PR TITLE
Add `report_count` to `CollectResp`

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1159,11 +1159,13 @@ and a body consisting of a `CollectResp`:
 
 ~~~
 struct {
+  uint64 report_count;
   HpkeCiphertext encrypted_agg_shares<1..2^32-1>;
 } CollectResp;
 ~~~
 
-The `encrypted_agg_shares` field is the vector of encrypted aggregate shares.
+* `report_count` is the number of reports included in the aggregation.
+* `encrypted_agg_shares` is the vector of encrypted aggregate shares.
 They MUST appear in the same order as the aggregator endpoints list of the task
 parameters.
 


### PR DESCRIPTION
This adds a field to collect responses with the number of reports that contributed to the aggregation. Collectors will likely want this count to aid in the interpretation of aggregate results. (see #163) There is also a change in draft-irtf-cfrg-vdaf-02 that opens the door for VDAFs that would require the report count during unsharding. (see cfrg/draft-irtf-cfrg-vdaf#95)

Note that while this field is not part of the adjacent `HpkeCiphertext`s, it will be protected by to the confidentiality of HTTPS and the leader-collector bearer token authentication.