### PR TITLE
Allow leader to remove collect results without an explicit DELETE.

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1164,7 +1164,7 @@ If obtaining aggregate shares fails, then the leader responds to subsequent HTTP
 GET requests to the collect job URI with an HTTP error status and a problem
 document as described in {{errors}}.
 
-The collector may send an HTTP DELETE request to the collect job URI, to which
+The collector can send an HTTP DELETE request to the collect job URI, to which
 the leader MUST respond with HTTP status 204 No Content. The leader MAY respond
 with HTTP status 204 No Content for requests to a collect job URI which has not
 received a DELETE request, for example if the results have been deleted due to

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1164,14 +1164,9 @@ If obtaining aggregate shares fails, then the leader responds to subsequent HTTP
 GET requests to the collect job URI with an HTTP error status and a problem
 document as described in {{errors}}.
 
-The leader MUST retain a collect job's results until the collector sends an HTTP
-DELETE request to the collect job URI, in which case the leader responds with
-HTTP status 204 No Content.
-
-[OPEN ISSUE: Allow the leader to drop aggregate shares after some reasonable
-amount of time has passed, but it's not clear how to specify that. ACME doesn't
-bother to say anything at all about this when describing how subscribers should
-fetch certificates: https://datatracker.ietf.org/doc/html/rfc8555#section-7.4.2]
+The leader MUST remove a collect job's results when the collector sends an HTTP
+DELETE request to the collect job URI. The leader responds with HTTP status 204
+No Content for requests to a collect job URI whose results have been removed.
 
 [OPEN ISSUE: Describe how intra-protocol errors yield collect errors (see
 issue#57). For example, how does a leader respond to a collect request if the

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1164,9 +1164,11 @@ If obtaining aggregate shares fails, then the leader responds to subsequent HTTP
 GET requests to the collect job URI with an HTTP error status and a problem
 document as described in {{errors}}.
 
-The leader MUST remove a collect job's results when the collector sends an HTTP
-DELETE request to the collect job URI. The leader responds with HTTP status 204
-No Content for requests to a collect job URI whose results have been removed.
+The collector may send an HTTP DELETE request to the collect job URI, to which
+the leader MUST respond with HTTP status 204 No Content. The leader MAY respond
+with HTTP status 204 No Content for requests to a collect job URI which has not
+received a DELETE request. The leader MUST respond to subsequent requests to
+the collect job URI with HTTP status 204 No Content.
 
 [OPEN ISSUE: Describe how intra-protocol errors yield collect errors (see
 issue#57). For example, how does a leader respond to a collect request if the

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1167,8 +1167,9 @@ document as described in {{errors}}.
 The collector may send an HTTP DELETE request to the collect job URI, to which
 the leader MUST respond with HTTP status 204 No Content. The leader MAY respond
 with HTTP status 204 No Content for requests to a collect job URI which has not
-received a DELETE request. The leader MUST respond to subsequent requests to
-the collect job URI with HTTP status 204 No Content.
+received a DELETE request, for example if the results have been deleted due to
+age. The leader MUST respond to subsequent requests to the collect job URI with
+HTTP status 204 No Content.
 
 [OPEN ISSUE: Describe how intra-protocol errors yield collect errors (see
 issue#57). For example, how does a leader respond to a collect request if the


### PR DESCRIPTION
The previous wording required the leader to store collect results until
the collector sent an explicit DELETE request to the collect job's URI.
Now, the relevant text is reworded to allow the leader to remove collect
results for other reasons (for example, a leader can now garbage-collect
old results after a suitable period of time).

This fell out of discussion on #288.