### PR TITLE
Add support for fixed-size tasks

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -386,8 +386,8 @@ in the "type" field (within the DAP URN namespace
 | reportTooLate              | Report could not be processed because it arrived too late. |
 | reportTooEarly             | Report could not be processed because its timestamp is too far in the future. |
 | batchInvalid               | A collect or aggregate-share request was made with invalid batch parameters. |
-| insufficientBatchSize      | There are not enough reports in the batch interval to satisfy the task's minimum batch size. |
-| batchLifetimeExceeded      | The batch lifetime has been exceeded for one or more reports included in the batch interval. |
+| invalidBatchSize           | There are an invalid number of reports in the batch. |
+| batchLifetimeExceeded      | The batch lifetime has been exceeded for one or more reports included in the batch. |
 | batchMismatch              | Aggregators disagree on the report shares that were aggregated in a batch. |
 | unauthorizedRequest        | Authentication of an HTTP request failed (see {{https-sender-auth}}). |
 
@@ -458,12 +458,8 @@ struct {
   Duration duration;
 } Interval;
 
-/* A nonce used to uniquely identify a report in the context of a DAP task. It
-includes the timestamp of the current batch and a random 16-byte value. */
-struct {
-  Time time;
-  uint8 rand[16];
-} Nonce;
+/* A nonce used to uniquely identify a report in the context of a DAP task. */
+Nonce uint8[16];
 
 /* The various roles in the DAP protocol. */
 enum {
@@ -484,6 +480,124 @@ struct {
 } HpkeCiphertext;
 ~~~
 
+## Queries {#query}
+
+Aggregated results are computed based on sets of report, called batches. The
+Collector influences which reports are used in a batch via a "query." The
+Aggregators use this query to carry out the aggregation flow and produce
+aggregate shares encrypted to the Collector.
+
+This document defines the following query types:
+
+~~~
+enum {
+   reserved(0), // Reserved for testing purposes
+   time-interval(1),
+   fixed-size(2),
+   (65535)
+} QueryType;
+~~~
+
+The time-interval query type is described in {{time-interval-query}}; the
+fixed-size query type is described in {{fixed-size-query}}. Future
+specifications can introduce new query types as needed. A query includes
+parameters used by the Aggregators to select a batch of reports specific to the
+given query type. A query is defined as follows:
+
+~~~
+enum {
+    next-batch(0),
+    by-batch-id(1),
+} FixedSizeQueryType;
+
+opaque BatchId[32];
+
+struct {
+    FixedSizeQueryType fixed_size_query_type;
+    select (fixed_size_query_type) {
+        next-batch:  Empty;
+        by-batch-id: BatchId batch_id;
+    }
+} FixedSizeQuery;
+
+struct {
+    select (query_type) { // determined by query configuration
+        case time-interval: Interval batch_interval;
+        case fixed-size: FixedSizeQuery fixed_size_query;
+    }
+} Query;
+~~~
+
+The parameters pertaining to each query type are described in one of the
+subsections below. The query is issued in-band as part of the collect
+sub-protocol ({{collect-flow}}). Its content is determined by the "query type",
+which in turn is encoded by the "query configuration" configured out-of-band.
+All query types have the following configuration parameters in common:
+
+- `min_batch_size` - The smallest number of reports the batch is allowed to
+  include. In a sense, this parameter controls the degree of privacy that will
+  be obtained: The larger the minimum batch size, the higher degree of privacy.
+  However, this ultimately depends on the application and the nature of the
+  reports and aggregation function.
+
+- `time_precision` - Clients use this value to truncate their report timestamps;
+  see {{upload-flow}}. Additional semantics may apply, depending on the query
+  type. (See {{batch-validation}} for details.)
+
+The parameters pertaining to specific query types are described in the relevant
+subsection below.
+
+### Time-interval Queries {#time-interval-query}
+
+The first query type, `time-interval`, is designed to support applications in
+which reports are collected over a long period of time. The Collector specifies
+a "batch interval" that determines the time range for reports included in the
+batch: For each report in the batch, the time at which that report was generated
+(see {{upload-flow}}) must fall within the batch interval specified by the
+Collector.
+
+Typically the Collector issues queries for which the batch intervals are
+continuous, monotonically increasing, and have the same duration. For example,
+the sequence of batch intervals. For example, the sequence of batch intervals
+`(1659544000, 1000)`, `(1659545000, 1000)`, `(1659545000, 1000)`, `(1659546000,
+1000)` satisfies these conditions. (The first element of the pair denotes the
+start of the batch interval and the second denotes the duration.) Of course,
+there are cases in which Collector may need to issue queries out-of-order. For
+example, a previous batch might need to be queried again with a different
+aggregation parameter (e.g, for Poplar1). In addition, the Collector may need to
+vary the duration to adjust to changing report upload rates.
+
+### Fixed-size Queries {#fixed-size-query}
+
+The `fixed-size` query type is used to support applications in which the
+Collector needs the ability to strictly control the sample size. This is
+particularly important for controlling the amount of noise added to reports
+by Clients (or added to aggregate shares by Aggregators) in order to achieve
+differential privacy.
+
+To get the aggregate of the next batch, the Collector issues a query of type
+`next-batch`. (See FixedSizeQuery in {{query}}.) The response to this query (see
+{{collect-flow}}) includes a "batch ID", which can be used to query the same
+batch later on. This is done using the `by-batch-id` batch-query type.
+
+For this query type, the Aggregators group reports into arbitrary batches such
+that each batch has roughly the same number of reports. In addition to the
+minumum batch size common to all query types, the conifugration includes a
+"maximum batch size", `max_batch_size`, that determines maximum number of
+reports per batch.
+
+Implementation note: The goal for the Aggregators is to aggregate precisely
+`min_batch_size` reports per batch. Doing so, however, may be challenging
+for Leader deployments in which multiple, independent nodes running the
+aggregate sub-protocol (see {{aggregate-flow}}) need to be coordinated. The
+maximum batch size is intended to allow room for error. Typically the difference
+between the minimum and maximum batch size will be a small fraction of the
+target batch size for each batch.
+
+[OPEN ISSUE: It may be feasible to require a fixed batch size, i.e.,
+`min_batch_size == max_batch_size`. We should know better once we've had some
+implementation/deployment experience.]
+
 ## Task Configuration {#task-configuration}
 
 Prior to the start of execution of the protocol, each participant must agree on
@@ -502,13 +616,11 @@ number generator. Each task has the following parameters associated with it:
   leader's endpoint MUST be the first in the list. The order of the
   `encrypted_input_shares` in a `Report` (see {{upload-flow}}) MUST be the
   same as the order in which aggregators appear in this list.
+* The query configuration for this task (see {{query}}). This determines the
+  query type for batch selection and the properties that all batches for this
+  task must have.
 * `max_batch_lifetime`: The maximum number of times a batch of reports may be
-  used in collect requests.
-* `min_batch_size`: The minimum number of reports that appear in a batch.
-* `min_batch_duration`: The minimum time difference between the oldest and
-  newest report in a batch. This defines the boundaries with which the batch
-  interval of each collect request must be aligned. (See
-  {{batch-parameter-validation}}.)
+  queried by the Collector.
 * A unique identifier for the VDAF instance used for the task, including the
   type of measurement associated with the task.
 
@@ -605,46 +717,52 @@ structured as follows:
 
 ~~~
 struct {
+    Time time;
+    Nonce nonce;
+    Extension extensions<0..2^16-1>;
+} ReportMetadata;
+
+struct {
   TaskID task_id;
-  Nonce nonce;
-  Extension extensions<0..2^16-1>;
+  ReportMetadata metadata;
   HpkeCiphertext encrypted_input_shares<1..2^32-1>;
 } Report;
 ~~~
 
-This message is called the client's report. It contains the following fields:
+This message is called the Client's report. It consists of a "header" and the
+encrypted input share of each of the Aggregators. The header consists of the
+task ID and report "metadata". The metadata consists of the following fields:
 
-* `task_id` is the task ID of the task for which the report is intended.
-* `nonce` is the report nonce generated by the client. This field is used by the
-  aggregators to ensure the report appears in at most one batch. (See
-  {{anti-replay}}.)
-* `extensions` is a list of extensions to be included in the Upload flow; see
-  {{upload-extensions}}.
-* `encrypted_input_shares` contains the encrypted input shares of each of the
-  aggregators. The order in which the encrypted input shares appear MUST match
-  the order of the task's `aggregator_endpoints` (i.e., the first share should
-  be the leader's, the second share should be for the first helper, and so on).
+* A timestamp representing the time at which the report was generated.
+  Specifically, the `time` field is set to the number of seconds elapsed since
+  the start of the UNIX epoch. The client SHOULD round this value down to the nearest
+  multiple of `time_precision` in order to ensure that that the timestamp cannot
+  be used to link a report back to the Client that generated it.
 
-To generate the report, the client begins by initializing the report nonce.
-Specifically, the client first sets `Nonce.rand` to 16 random bytes output from
-a cryptographically secure random number generator. It then sets `Nonce.time`
-to the number of seconds elapsed since the start of the UNIX epoch, rounded down to the nearest multiple of `min_batch_duration`.
-This truncation is done to ensure that the report's timestamp cannot be used to
-link the report back to the originating client.
+* A nonce used by the Aggregators to ensure the report appears in at most one
+  batch. (See {{anti-replay}}.) The Client MUST generate this by generating 16
+  random bytes using a cryptographically secure random number gnerator.
 
-The client then finishes the report generation by sharding its measurement into
-a sequence of input shares as specified by the VDAF in use. To encrypt an input
-share, the client generates an {{HPKE}} ciphertext for the aggregator by running
+* A list of extensions to be included with the report. (See
+  {{upload-extensions}}.)
+
+To generate a report, the Client first shards its measurement into input shares
+as specified by the VDAF. It then encrypts each input share as follows:
 
 ~~~
-enc, payload = SealBase(pk, "dap-01 input share" || 0x01 || server_role,
-    task_id || nonce || extensions, input_share)
+enc, payload = SealBase(pk,
+    "dap-01 input share" || 0x01 || server_role,
+    task_id || metadata, input_share)
 ~~~
 
 where `pk` is the aggregator's public key; `server_role` is the Role of the
-intended recipient (`0x02` for the leader and `0x03` for the helper);
-`task_id`, `nonce`, and `extensions` are the corresponding fields of `Report`;
-and `input_share` is the aggregator's input share.
+intended recipient (`0x02` for the leader and `0x03` for the helper), `task_id`
+is the task ID, `metadata` is the report metadata, and `input_share` is the
+Aggregator's input share.
+
+The order of the encrypted input shares appear MUST match the order of the
+task's `aggregator_endpoints`. That is, the first share should be the leader's,
+the second share should be for the first helper, and so on.
 
 The leader responds to well-formed requests to `[leader]/upload` with HTTP status
 code 200 OK and an empty body. Malformed requests are handled as described in {{errors}}.
@@ -658,12 +776,11 @@ cached aggregator `HpkeConfig` and retry with a freshly generated Report. If
 this retried report does not succeed, clients MUST abort and discontinue
 retrying.
 
-The leader MUST ignore any report whose nonce contains a timestamp that falls in
-a batch interval for which it has received at least one collect request from the
-collector. (See {{collect-flow}}.) Otherwise, comparing the aggregate result to
-the previous aggregate result may result in a privacy violation. (Note that the
-helpers enforce this as well; see {{collect-flow}}.) In addition, the
-leader SHOULD abort the upload protocol and alert the client with error
+The Leader MUST ignore any report pertaining to a batch that has already been
+collected. (See {{input-share-batch-validation}} for details.) Otherwise,
+comparing the aggregate result to the previous aggregate result may result in a
+privacy violation. (Note that the Helpers enforce this as well.) In addition,
+the leader SHOULD abort the upload protocol and alert the client with error
 "reportTooLate".
 
 Leaders can buffer reports while waiting to aggregate them. The leader SHOULD
@@ -789,6 +906,7 @@ enum {
   hpke-unknown-config-id(3),
   hpke-decrypt-error(4),
   vdaf-prep-error(5),
+  batch-saturated(6),
 } ReportShareError;
 ~~~
 
@@ -814,8 +932,7 @@ structured as follows:
 
 ~~~
 struct {
-  Nonce nonce;
-  Extension extensions<0..2^16-1>;
+  ReportMetadata metadata;
   HpkeCiphertext encrypted_input_share;
 } ReportShare;
 
@@ -823,20 +940,48 @@ struct {
   TaskID task_id;
   AggregationJobID job_id;
   opaque agg_param<0..2^16-1>;
+  select (query_type) { // determined by task configuration
+    time-interval: Empty;
+    fixed-size: BatchId batch_id;
+  }
   ReportShare report_shares<1..2^32-1>;
 } AggregateInitializeReq;
 ~~~
 
-[[OPEN ISSUE: consider sending report shares separately (in parallel) to the aggregate instructions. RIght now, aggregation parameters and the corresponding report shares are sent at the same time, but this may not be strictly necessary. ]]
+[[OPEN ISSUE: Consider sending report shares separately (in parallel) to the
+aggregate instructions. Right now, aggregation parameters and the corresponding
+report shares are sent at the same time, but this may not be strictly
+necessary.]]
 
-The `nonce` and `extensions` fields of each ReportShare match that in the Report
-uploaded by the client. The `encrypted_input_share` field is the `HpkeCiphertext`
-whose index in `Report.encrypted_input_shares` is equal to the index of the aggregator
-in the task's `aggregator_endpoints` to which the AggregateInitializeReq is being sent.
-The `agg_param` field is an opaque, VDAF-specific aggregation parameter provided during a collection flow.
-The `job_id` parameter contains the leader's chosen AggregationJobID.
+This message consists of:
 
-[[OPEN ISSUE: Check that this handling of `agg_param` is appropriate when the definition of Poplar is done.]]
+* The ID of the task for which the reports will be aggregated.
+
+* The aggregation job ID.
+
+* The opaque, VDAF-specific aggregation parameter provided during the
+  collection flow (`agg_param`),
+
+  [[OPEN ISSUE: Check that this handling of `agg_param` is appropriate when the
+  definition of Poplar is done.]]
+
+* Information used by the Aggregators to determine how to aggregate each report:
+
+    * For fixed-size tasks, the Leader specifies a "batch ID" that determines
+      the batch to which each report for this aggregation job belongs.
+
+      [OPEN ISSUE: For fixed-size tasks, the Leader is in complete control over
+      which batch a report is included in. For time-interval tasks, the Client has
+      some control, since the timestamp determines which batch window it falls
+      in. Is this desirable from a privacy perspective? If not, it might be
+      simpler to drop the timestamp altogether and have the agg init request
+      specify the batch window instead.]
+
+* The sequence of report shares to aggregate. The `encrypted_input_share` field
+  of the report share is the `HpkeCiphertext` whose index in
+  `Report.encrypted_input_shares` is equal to the index of the aggregator in the
+  task's `aggregator_endpoints` to which the AggregateInitializeReq is being
+  sent.
 
 Let `[aggregator]` denote the helper's API endpoint. The leader sends a POST
 request to `[aggregator]/aggregate` with its AggregateInitializeReq message as
@@ -907,18 +1052,19 @@ abort with error "unrecognizedMessage".
 
 #### Input Share Decryption {#input-share-decryption}
 
-Each report share has a corresponding task ID, nonce, list of extensions, and encrypted
-input share. Let `task_id`, `nonce`, `extensions`, and `encrypted_input_share` denote these
-values, respectively. Given these values, an aggregator decrypts the input
-share as follows. First, the aggregator looks up the HPKE config and corresponding
-secret key indicated by `encrypted_input_share.config_id`. If not found, then it
-marks the report share as invalid with the error `hpke-unknown-config-id`.
-Otherwise, it decrypts the payload with the following procedure:
+Each report share has a corresponding task ID, report metadata (timestamp,
+nonce, and extensions), and encrypted input share. Let `task_id`, `metadata`,
+and `encrypted_input_share` denote these values, respectively. Given these
+values, an aggregator decrypts the input share as follows. First, the aggregator
+looks up the HPKE config and corresponding secret key indicated by
+`encrypted_input_share.config_id`. If not found, then it marks the report share
+as invalid with the error `hpke-unknown-config-id`. Otherwise, it decrypts the
+payload with the following procedure:
 
 ~~~
-input_share = OpenBase(encrypted_input_share.enc, sk, "dap-01 input share" ||
-    0x01 || server_role, task_id || nonce || extensions,
-    encrypted_input_share.payload)
+input_share = OpenBase(encrypted_input_share.enc, sk,
+    "dap-01 input share" || 0x01 || server_role,
+    task_id || metadata, encrypted_input_share.payload)
 ~~~
 
 where `sk` is the HPKE secret key, and `server_role` is the role of the
@@ -935,16 +1081,22 @@ The validation checks are as follows.
 
 1. Check if the report has never been aggregated but is contained by
    a batch that has been collected. If this check fails, the input share
-   is marked as invalid with the error `batch-collected`. This prevents
+   MUST be marked as invalid with the error `batch-collected`. This prevents
    additional reports from being aggregated after its batch has already
    been collected.
 2. Check if the report has already been aggregated with this aggregation
-   parameter. If this check fails, the input share is marked as invalid with
-   the error `report-replayed`. This is the case if the report was used in a
-   previous aggregate request and is therefore a replay. An aggregator may also
-   choose to mark an input share as invalid with the  error `report-dropped`
-   under the conditions prescribed in {{anti-replay}}.
-
+   parameter. If this check fails, the input share MUST be marked as invalid
+   with the error `report-replayed`. This is the case if the report was used in
+   a previous aggregate request and is therefore a replay. An aggregator may
+   also choose to mark an input share as invalid with the error
+   `report-dropped` under the conditions prescribed in {{anti-replay}}.
+3. Depending on the query type for the task, additional checks may be applicable:
+    * For fixed-size tasks, the Aggregators need to ensure that each batch is
+      roughly the same size. If the number of reports aggregated for the current
+      batch exceeds the maximum batch size (per the task configuration), the
+      Aggregator MAY mark the input share as invalid with the error
+      "batch-saturated". Note that this behavior is not strictly enforced here
+      but during the collect sub-protocol. (See {{batch-validation}}.)
 If both checks succeed, the input share is not marked as invalid.
 
 #### Input Share Preparation {#input-share-prep}
@@ -1086,12 +1238,12 @@ The helper then awaits the next message from the leader.
 
 ## Collecting Results {#collect-flow}
 
-In this phase, the collector requests aggregate shares from each aggregator
-and then locally combines them to yield a single, aggregate output. In particular,
-the collector asks the leader to collect and return the results for a given
-DAP task over a given time period. The aggregate shares are encrypted to the
-collector so that it can decrypt and combine them to yield the aggregate output.
-This entire process is composed of two interactions:
+In this phase, the Collector requests aggregate shares from each aggregator and
+then locally combines them to yield a single aggregate result. In particular,
+the Collector issues a query to the Leader ({{query}}), which the Aggregators
+use to select a batch of reports to aggregate. Each emits an aggregate share
+encrypted to the Collector so that it can decrypt and combine them to yield the
+aggregate result. This entire process is composed of two interactions:
 
 1. Collect request and response between the collector and leader, specified
    in {{collect-init}}
@@ -1115,7 +1267,7 @@ attacks.]
 ~~~
 struct {
   TaskID task_id;
-  Interval batch_interval;
+  Query query;
   opaque agg_param<0..2^16-1>; // VDAF aggregation parameter
 } CollectReq;
 ~~~
@@ -1123,27 +1275,27 @@ struct {
 The named parameters are:
 
 * `task_id`, the DAP task ID.
-* `batch_interval`, the request's batch interval.
+* `query`, the Collector's query.
 * `agg_param`, an aggregation parameter for the VDAF being executed.
   This is the same value as in `AggregateInitializeReq` (see {{leader-init}}).
 
 Depending on the VDAF scheme and how the leader is configured, the leader and
-helper may already have prepared all the reports falling within `batch_interval`
-and be ready to return the aggregate shares right away, but this cannot be
+helper may already have prepared a sufficient number of reports satisfying the
+query and be ready to return the aggregate shares right away, but this cannot be
 guaranteed. In fact, for some VDAFs, it is not be possible to begin preparing
 inputs until the collector provides the aggregation parameter in the
 `CollectReq`. For these reasons, collect requests are handled asynchronously.
 
 Upon receipt of a `CollectReq`, the leader begins by checking that the request
 meets the requirements of the batch parameters using the procedure in
-{{batch-parameter-validation}}. If so, it immediately sends the collector a
+{{batch-validation}}. If so, it immediately sends the collector a
 response with HTTP status 303 See Other and a Location header containing a URI
 identifying the collect job that can be polled by the collector, called the
 "collect job URI".
 
-The leader then begins working with the helper to prepare the shares falling
-into `CollectReq.batch_interval` (or continues this process, depending on the
-VDAF) as described in {{aggregate-flow}}.
+The leader then begins working with the helper to prepare the shares satisfying
+the query (or continues this process, depending on the VDAF) as described in
+{{aggregate-flow}}.
 
 After receiving the response to its CollectReq, the collector makes an HTTP GET
 request to the collect job URI to check on the status of the collect job and
@@ -1159,15 +1311,24 @@ and a body consisting of a `CollectResp`:
 
 ~~~
 struct {
+  select (query_type) { // determined by task configuration
+    time-interval: Empty;
+    fixed-size: BatchId batch_id;
+  }
   uint64 report_count;
   HpkeCiphertext encrypted_agg_shares<1..2^32-1>;
 } CollectResp;
 ~~~
 
-* `report_count` is the number of reports included in the aggregation.
-* `encrypted_agg_shares` is the vector of encrypted aggregate shares.
-They MUST appear in the same order as the aggregator endpoints list of the task
-parameters.
+This structure includes the following:
+
+* information used to bind the aggregate result to the query. For fixed-size
+  tasks, this includes the batch ID assigned to the batch by the Leader.
+
+* The number of reports included in the batch.
+
+* The vector of encrypted aggregate shares. They MUST appear in the same order
+  as the aggregator endpoints list of the task parameters.
 
 If obtaining aggregate shares fails, then the leader responds to subsequent HTTP
 GET requests to the collect job URI with an HTTP error status and a problem
@@ -1188,10 +1349,10 @@ helper drops out?]
 
 The leader obtains each helper's encrypted aggregate share in order to respond
 to the collector's collect response. To do this, the leader first computes a
-checksum over the set of output shares included in the batch window identified
-by the collect request. The checksum is computed by taking the SHA256 hash of
-each nonce from the client reports included in the aggregation, then combining
-the hash values with a bitwise-XOR operation.
+checksum over the set of output shares included in the batch. The checksum is
+computed by taking the SHA256 hash of each nonce from the client reports
+included in the aggregation, then combining the hash values with a bitwise-XOR
+operation.
 
 Then, for each aggregator endpoint `[aggregator]` in the parameters associated
 with `CollectReq.task_id` (see {{collect-flow}}) except its own, the leader sends
@@ -1199,31 +1360,49 @@ a POST request to `[aggregator]/aggregate_share` with the following message:
 
 ~~~
 struct {
+  select (query_type) { // determined by task configuration
+    time-interval: Interval batch_interval;
+    fixed-size: BatchId batch_id;
+  }
+} BatchSelector;
+
+struct {
   TaskID task_id;
-  Interval batch_interval;
+  BatchSelector batch_selector;
   opaque agg_param<0..2^16-1>;
   uint64 report_count;
   opaque checksum[32];
 } AggregateShareReq;
 ~~~
 
-* `task_id` is the task ID associated with the DAP parameters.
-* `batch_interval` is the batch interval of the request.
-* `agg_param`, an aggregation parameter for the VDAF being executed.
-  This is the same value as in `AggregateInitializeReq` (see {{leader-init}})
-  and in `CollectReq` (see {{collect-init}}).
-* `report_count` is the number of reports included in the aggregation.
-* `checksum` is the checksum computed over the set of client reports.
+The message contains the following parameters:
+
+* The task ID.
+
+* The "batch seletor", which encodes parameters used to determine the batch
+  being aggregated. The value depends on the query type for the task:
+
+    * For time-interval tasks, the request specifies the batch interval.
+
+    * For fixed-size tasks, the request specifies the batch ID.
+
+* The opaque aggregation parameter for the VDAF beging executed. This value MUST
+  match the same value in the the `AggregateInitializeReq` message sent in at
+  least one run of the aggregate sub-protocol. (See {{leader-init}}). and in
+  `CollectReq` (see {{collect-init}}).
+
+* The number number of reports included in the batch.
+
+* The batch checksum.
 
 This request MUST be authenticated as described in {{https-sender-auth}}. To
 handle the leader's request, the helper first ensures that the request meets the
 requirements for batch parameters following the procedure in
-{{batch-parameter-validation}}.
+{{batch-validation}}.
 
-Next, it computes a checksum based on its view of the output shares included in
-the batch window, and checks that the `report_count` and `checksum` included in
-the request match its computed values. If not, then it MUST abort with error
-"batchMismatch".
+Next, it computes a checksum based on the reports that satisfy the query, and
+checks that the `report_count` and `checksum` included in the request match its
+computed values. If not, then it MUST abort with error "batchMismatch".
 
 Next, it computes the aggregate share `agg_share` corresponding to the set of
 output shares, denoted `out_shares`, for the batch interval, as follows:
@@ -1235,7 +1414,7 @@ agg_share = VDAF.out_shares_to_agg_share(agg_param, out_shares)
 Note that for most VDAFs, it is possible to aggregate output shares as they
 arrive rather than wait until the batch is collected. To do so however, it is
 necessary to enforce the batch parameters as described in
-{{batch-parameter-validation}} so that the aggregator knows which aggregate
+{{batch-validation}} so that the aggregator knows which aggregate
 share to update.
 
 The helper then encrypts `agg_share` under the collector's HPKE public
@@ -1260,10 +1439,10 @@ computed above and `encrypted_aggregate_share.ciphertext` is the ciphertext
 After receiving the helper's response, the leader uses the HpkeCiphertext to
 respond to a collect request (see {{collect-flow}}).
 
-After issuing an aggregate-share request for a given batch interval, it is an
-error for the leader to issue any more aggregate or aggregate-init requests for
-additional reports in the batch interval. These reports will be rejected by helpers as
-described {{agg-init}}.
+After issuing an aggregate-share request for a given query, it is an error for
+the leader to issue any more aggregation jobs for additional reports that
+satisfy the query. These reports will be rejected by helpers as described
+{{agg-init}}.
 
 Before completing the collect request, the leader also computes its own aggregate
 share `agg_share` by aggregating all of the prepared output shares that fall within
@@ -1293,7 +1472,7 @@ as follows:
 
 ~~~
 enc, payload = SealBase(pk, "dap-01 aggregate share" || server_role || 0x00,
-  AggregateShareReq.task_id || AggregateShareReq.batch_interval, agg_share)
+  AggregateShareReq.task_id || AggregateShareReq.batch_selector, agg_share)
 ~~~
 
 where `pk` is the HPKE public key encoded by the collector's HPKE key,
@@ -1305,49 +1484,98 @@ given batch interval, denoted `batch_interval`, decryption works as follows:
 
 ~~~
 agg_share = OpenBase(enc_share.enc, sk, "dap-01 aggregate share" ||
-    server_role || 0x00, task_id || batch_interval, enc_share.payload)
+    server_role || 0x00, task_id || batch_selector, enc_share.payload)
 ~~~
 
 where `sk` is the HPKE secret key, `task_id` is the task ID for the collect
 request, and `server_role` is the role of the server that sent the aggregate
-share (`0x02` for the leader and `0x03` for the helper).
+share (`0x02` for the leader and `0x03` for the helper). The value of
+`batch_selector` is computed by the Collector from its query and the response to
+its query:
 
-### Validating Batch Parameters {#batch-parameter-validation}
+* For time-interval tasks, the batch selector is the batch interval specified in
+  the query.
 
-Before an aggregator responds to a collect request or aggregate-share request,
-it must first check that the request does not violate the parameters associated
-with the DAP task. It does so as described here.
+* For fixed-size tasks, the batch selector is the batch ID assigned sent in the
+  response.
 
-First the aggregator checks that the request's batch interval respects the
-boundaries defined by the DAP task's parameters. Namely, it checks that both
-`batch_interval.start` and `batch_interval.duration` are divisible by
-`min_batch_duration` and that `batch_interval.duration >= min_batch_duration`.
-Unless both these conditions are true, the aggregator MUST abort and alert its
-peer with error "batchInvalid".
+### Batch Validation {#batch-validation}
 
-Next, the aggregator checks that the request respects the generic privacy
-parameters of the DAP task. Let `X` denote the set of reports for which the
-aggregator has recovered a valid output share and which fall in the batch
-interval of the request.
+Before an Aggregator responds to a CollectReq or AggregateShareReq, it must
+first check that the request does not violate the parameters associated with the
+DAP task. It does so as described here.
 
-* If `len(X) < min_batch_size`, then the aggregator MUST abort and alert its
-  peer with "insufficientBatchSize".
-* The aggregator keeps track of the number of times each report was added to the
-  batch of an AggregateShareReq. If any report in `X` was added to at least
-  `max_batch_lifetime` previous batches, then the aggregator MUST abort and
-  alert the peer with "batchLifetimeExceeded".
+First the Aggregator checks that the batch respects any "boundaries" determined
+by the query type. These are described in the subsections below. If the boundary
+check fails, then the Aggregator MUST abort with error "batchInvalid".
 
-Finally, the aggregator checks that the batch interval defined by the collect
-request satisfies one of the conditions:
+Next, the Aggregator checks that batch contains a valid number of reports, as
+determined by the query type. If the size check fails, then the Aggregator MUST
+abort with error "invalidBatchSize".
 
-1. The batch interval does not overlap with the batch interval of any prior
-   completed collect requests.
-1. The batch interval, including its start and duration values, match a prior
-   completed collect request.
+Next, the Aggregator checks that the batch has not been aggregated too many
+times. This is determined by the maximum batch lifetime, `max_batch_lifetime`.
+Unless the query has been issued less than `max_batch_lifetime` times, the
+Aggregator MUST abort with error "batchLifetimeExceeded".
+
+Finally, the Aggregator checks that the batch does not contain a report that was
+included in any previous batch. If this batch overlap check fails, then the
+Aggregator MUST abort with error "batchOverlap". For time-interval tasks, it is
+sufficient (but not necessary) to check that the batch interval does not overlap
+with the batch interval of any previous query. If this batch interval check
+fails, then the Aggregator MAY abort with error "batchOverlap".
 
 [[OPEN ISSUE: #195 tracks how we might relax this constraint to allow for more
 collect query flexibility. As of now, this is quite rigid and doesn't give the
 collector much room for mistakes.]]
+
+#### Time-interval Queries {#time-interval-batch-validation}
+
+##### Boundary Check
+
+The batch boundaries are determined by the `time_precision` field of the query
+configuration. For the `batch_interval` included with the query, the Aggregator
+checks that:
+
+* `batch_interval.duration >= time_precision` (this field determines,
+  effectively, the minimum batch duration)
+
+* both `batch_interval.start` and `batch_interval.duration` are divisible by
+  `time_precision`
+
+These measures ensure that Aggregators can efficiently "pre-aggregate" output
+shares recovered during the aggregation sub-protocol.
+
+##### Size Check
+
+The query configuration specifies the minimum batch size, `min_batch_size`. The
+Aggregator checks that `len(X) >= min_batch_size`, where `X` is the set of
+reports in the batch.
+
+#### Fixed-size Queries {#fixed-size-batch-validation}
+
+##### Boundary Check
+
+For fixed-size tasks, the batch boundaries are defined by "batch IDs" selected
+by the Leader. Thus the Aggregator needs to check that the query is associated
+with a known batch ID:
+
+* If the query contained in the CollectReq has type `by-batch-id`, the
+  Leader checks that the provided batch ID corresponds to a batch ID it
+  returned in a previous CollectResp for the task.
+
+  [OPEN ISSUE: Consider making batch IDs predictable. See issue #301.]
+
+* The Helper checks that the batch ID provided by the leader in its
+  AggregateShareReq corresponds to a batch ID used in a previous
+  AggregateInitializeReq for the task.
+
+##### Size Check
+
+The query configuration specifies the minimum batch size, `min_batch_size`, and
+maximum batch size, `max_batch_size`. The Aggregator checks that `len(X) >=
+min_batch_size` and `len(X) <= max_batch_size`, where `X` is the set of reports
+in the batch.
 
 ### Anti-replay {#anti-replay}
 
@@ -1359,10 +1587,10 @@ detect and filter out replayed reports.
 
 To detect replay attacks, each aggregator keeps track of the set of nonces
 pertaining to reports that were previously aggregated for a given task. If the
-leader receives a report from a client whose nonce is in this set, it simply
-ignores it. A helper who receives an encrypted input share whose nonce is
-in this set replies to the leader with an error as described in
-{{input-share-batch-validation}}.
+leader receives a report from a client whose nonce is in this set, it either
+ignores it or aborts the upload sub-protocol as described in {{upload-flow}}. A
+Helper who receives an encrypted input share whose nonce is in this set rejects
+the report as described in {{input-share-batch-validation}}.
 
 [OPEN ISSUE: This has the potential to require aggreagtors to store nonce sests
 indefinitely. See issue#180.]
@@ -1375,7 +1603,7 @@ the output share is only recovered if the aggregator is given the correct nonce.
 
 Aggregators prevent the same report from being used in multiple batches (except
 as required by the protocol) by only responding to valid collect requests, as
-described in {{batch-parameter-validation}}.
+described in {{batch-validation}}.
 
 # Operational Considerations {#operational-capabilities}
 
@@ -1493,7 +1721,7 @@ is only run once per report, each aggregator only needs to store its
 aggregate share for each possible batch interval, along with the number of times
 the aggregate share was used in a batch. This is due to the requirement that the
 batch interval respect the boundaries defined by the DAP parameters. (See
-{{batch-parameter-validation}}.)
+{{batch-validation}}.)
 
 # Compliance Requirements {#compliance}
 


### PR DESCRIPTION
Closes #273.

Generalizes "batch_interval" to "query" and enumerate the different query
types and constraints that apply to each. The existing collect request
semantics is subsumed by the `time-interval` query type.

Adds a query type, `fixed-size`, that is designed to support use cases
in which the sample size needs to be tightly controlled. The main
feature of this query type is that the Aggregators enforce limits on the
size of each batch. We given them a little wiggle room in order to make
coordination of aggregation jobs a bit easier.

One notable feature of this change is that each tasks supports exactly
one query type. This allows us to punt on the coomplexity of having to
composing different query types per task. For example: If a report can
be batched into a chunk or a batch interval, then it's not clear that
it's possible for Aggregators to aggregate reports ahead of a collect
request.