### PR TITLE
Fixing FixedSizeQuerry presentation syntax

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -510,7 +510,7 @@ opaque BatchId[32];
 
 struct {
     FixedSizeQueryType fixed_size_query_type;
-    select (fixed_size_query_type) {
+    select (FixedSizeQuery.fixed_size_query_type) {
         next-batch:  Empty;
         by-batch-id: BatchId batch_id;
     }


### PR DESCRIPTION
I think this is right based on RFC 8446 always have a prefix like "FixedSizeQuery." when the choice comes after a type.