### PR TITLE
Editorial: Define PartialBatchSelector

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1014,14 +1014,18 @@ struct {
 } ReportShare;
 
 struct {
-  TaskID task_id;
-  AggregationJobID job_id;
-  opaque agg_param<0..2^16-1>;
   QueryType query_type;
-  select (AggregateInitializeReq.query_type) {
+  select (PartialBatchSelector.query_type) {
     case time_interval: Empty;
     case fixed_size: BatchID batch_id;
   };
+} PartialBatchSelector;
+
+struct {
+  TaskID task_id;
+  AggregationJobID job_id;
+  opaque agg_param<0..2^16-1>;
+  PartialBatchSelector part_batch_selector;
   ReportShare report_shares<1..2^32-1>;
 } AggregateInitializeReq;
 ~~~
@@ -1435,11 +1439,7 @@ job's URI with HTTP status code 200 OK and a body consisting of a `CollectResp`:
 
 ~~~
 struct {
-  QueryType query_type;
-  select (CollectResp.query_type) {
-    case time_interval: Empty;
-    case fixed_size: BatchID batch_id;
-  };
+  PartialBatchSelector part_batch_selector;
   uint64 report_count;
   HpkeCiphertext encrypted_agg_shares<1..2^32-1>;
 } CollectResp;


### PR DESCRIPTION
The BatchSelector is the value agreed upon by the Aggregators during the collect flow. It is used to guide selection of a batch of reports for computing the aggregate result.

Conceptually, a PartialBatchSelector is "promoted" to a BatchSelector once the Collector's query is determined. The PartialBatchSelector is used during the aggregation flow to assign reports to batches. For example, for fixed size queries, the BatchID is selected during the Leader during the aggregation flow.


This is not a functional change, but I ended up wanting this abstraction in my implementation, so I thought I'd upstream it.

cc/ @wangshan.