### PR TITLE
DO NOT MERGE sketch of resource oriented DAP API

### DIFF
--- a/api-resources.md
+++ b/api-resources.md
@@ -2,7 +2,6 @@
 
 DAP is structured as an HTTP-based application with the following resources:
 
-- (TODO) Tasks
 - HPKE configurations
 - Reports
 - Aggregation jobs
@@ -22,10 +21,6 @@ We use HTTP `PUT` requests for idempotent creation of resources. Server response
 Finally, a quick reminder of some HTTP semantics: `GET` and `PUT` are idempotent (i.e., the same request may be made multiple times without changing state in the server more than once, and the response will be the same each time). `POST` is not idempotent. `GET` requests may not have bodies.
 
 We care a lot about idempotence because we need to account for cases where a client makes a request but never sees the response, and thus needs a way to recover from this state of uncertainty.
-
-### Tasks
-
-TODO: do we want a task resource that we can GET and PUT in the protocol? Does this collide with https://wangshan.github.io/draft-wang-ppm-dap-taskprov/draft-wang-ppm-dap-taskprov.html or https://github.com/divergentdave/draft-dcook-ppm-dap-interop-test-design?
 
 ### HPKE configurations
 

--- a/api-resources.md
+++ b/api-resources.md
@@ -79,7 +79,7 @@ struct {
 
 ##### PUT
 
-Idempotent upload of a report to an aggregator. The request body is a `struct Report`.
+Idempotent upload of a report to an aggregator. The request body is a `struct Report`. Once uploaded, a report is immutable, meaning that subsequent `PUT` requests to a particular report resource that vary fields of `struct Report` MUST be rejected by the leader.
 
 This is analogous to DAP-02's `POST /upload`.
 
@@ -154,6 +154,8 @@ struct {
 ```
 
 If successful, the helper's response is a `struct AggregateJob` where `prepare_steps` contains the helper's first-round VDAF prepare messages for the report shares in `AggregateJobPutReq`, or errors if `vdaf.prepare` failed for any report.
+
+Once created, an aggregation job resource cannot be mutated with `PUT` requests. Subsequent `PUT` requests to an aggregation job MUST be rejected by helpers.
 
 This is analogous to DAP-02's `POST /aggregate` with an `AggregateInitReq`.
 
@@ -232,6 +234,8 @@ struct {
 
 If successful, the response from the helper is a `struct AggregateShare`. That same share may later be obtained by a GET request on the resource.
 
+Once it is created, an aggregate share cannot be mutated with a further `PUT` request. Subsequent `PUT` requests MUST be rejected by the helper.
+
 This is analogous to DAP-02's `POST /aggregate_share`.
 
 ###### A note on `BatchSelector.fixed_size`
@@ -294,6 +298,8 @@ struct {
 ```
 
 If successful, the response from the helper is a `struct Collection`. That same share may later be obtained by a GET request on the resource.
+
+Once created, a collection cannot be mutated with a further `PUT` request. Leaders MUST reject subsequent `PUT` requests to a collection resource.
 
 This is analogous to DAP-02's `POST /collect`.
 

--- a/api-resources.md
+++ b/api-resources.md
@@ -24,19 +24,13 @@ We care a lot about idempotence because we need to account for cases where an HT
 
 ### HPKE configurations
 
+This proposal deliberately does not address any of the open questions or issues around multiple HPKE configurations or negotiation (see #248) and preserves the existing `hpke_config` endpoint unchanged, in the interest of containing the scope of this proposal.
+
 #### Path
 
 `/hpke_config[?task_id=task-id]`
 
 The `task_id` query parameter is optional, as described in https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.1.
-
-##### Alternatives
-
-An HPKE config has an ID, so we could use a path `hpke_configs/hpke-config-id`. However, a client should never need to get any HPKE config except for the "current" one, so does it make sense to expand the API surface with a path param for HPKE config ID?
-
-`GET /hpke_config` could redirect to `/hpke_config/current-hpke-config-id`, which would make this mostly transparent to clients, assuming they handle 3xx redirects properly.
-
-Instead of providing the task ID as a query parameter, we could also include it in the path, like `/tasks/{task-id}/hpke_config`, on the premise that the task ID is part of the resource's permanent identity. However, it's awkward to solve the global HPKE config case with this formulation. We could include a special task ID "global" so that clients could query `/tasks/global/hpke_config`.
 
 #### Representation
 

--- a/api-resources.md
+++ b/api-resources.md
@@ -77,10 +77,6 @@ struct {
 
 #### Required HTTP methods
 
-##### GET/HEAD
-
-The response body is a `struct Report` representing the report.
-
 ##### PUT
 
 Idempotent upload of a report to an aggregator. The request body is a `struct Report`.

--- a/api-resources.md
+++ b/api-resources.md
@@ -50,7 +50,7 @@ struct {
 
 ##### GET/HEAD
 
-The response body is a `struct HpkeConfig` representing the `hpke_config`.
+The response body is a `struct HpkeConfig` representing the server's current `hpke_config`.
 
 ### Reports
 
@@ -125,7 +125,7 @@ See "POST", below, for explanation and justification of the `round` field.
 
 ##### GET/HEAD
 
-The response body is a `struct AggregateJob` representing the current state of the reports in the job.
+The response body is a `struct AggregateJob` representing the current state of the reports in the job. The server mays return an error if no aggregation job is known to it for the aggregation job ID, or if the aggregation job results have been discarded, whether in response to a `DELETE` request on the resource, the task having expired, or any other garbage collection policy the server implements.
 
 ##### PUT
 
@@ -207,7 +207,7 @@ struct {
 
 ##### GET/HEAD
 
-If the aggregate share is available, the result is a `struct AggregateShare`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such aggregate share is known to the helper.
+If the aggregate share is available, the result is a `struct AggregateShare`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such aggregate share is known to the helper. The server may also return an error if the aggregate share was discarded in response to a `DELETE` request on the resource, the task expiring or some other garbage collection policy implemented by the server.
 
 ##### PUT
 
@@ -272,7 +272,7 @@ struct {
 
 ##### GET/HEAD
 
-If the collection is available, the response body is a `struct Collection`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such aggregate share request is known to the server.
+If the collection is available, the response body is a `struct Collection`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such aggregate share request is known to the server. The server may also return an error if the collection was discarded due to a `DELETE` request on the resource, the task having expired, or some other garbage collection policy implemented by the server.
 
 This is analogous to DAP-02's `GET` on a collect job URI.
 

--- a/api-resources.md
+++ b/api-resources.md
@@ -125,7 +125,7 @@ See "POST", below, for explanation and justification of the `round` field.
 
 ##### GET/HEAD
 
-The response body is a `struct AggregateJob` representing the current state of the reports in the job. The server mays return an error if no aggregation job is known to it for the aggregation job ID, or if the aggregation job results have been discarded, whether in response to a `DELETE` request on the resource, the task having expired, or any other garbage collection policy the server implements.
+The response body is a `struct AggregateJob` representing the current state of the reports in the job. The server may return an error if no aggregation job is known to it for the aggregation job ID, or if the aggregation job results have been discarded, whether in response to a `DELETE` request on the resource, the task having expired, or any other garbage collection policy the server implements.
 
 ##### PUT
 
@@ -330,7 +330,7 @@ struct {
 
 If the collection is available, the response body is a `struct Collection`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such collection is known to the server. The server may also return an error if the collection was discarded due to a `DELETE` request on the resource, the task having expired, or some other garbage collection policy implemented by the server.
 
-Even after receiving a `struct Collection`, the collector MAY continue to send `POST` requests to a collect URI and the respones should still be the `struct Collection` (if it is still available and hasn't been garbage collected).
+Even after receiving a `struct Collection`, the collector MAY continue to send `POST` requests to a collect URI and the responses should still be the `struct Collection` (if it is still available and hasn't been garbage collected).
 
 See "Viewing fixed-size batches as a message queue" for discussion.
 

--- a/api-resources.md
+++ b/api-resources.md
@@ -5,9 +5,9 @@ DAP is structured as an HTTP-based application with the following resources:
 - (TODO) Tasks
 - HPKE configurations
 - Reports
-- Aggregation jobs (and lists thereof)
-- Aggregate shares (and lists thereof)
-- Collections (and lists thereof)
+- Aggregation jobs
+- Aggregate shares
+- Collections
 
 A resource's path is resolved relative to a server's base URL to construct a resource URI. Deployments may host resource paths arbitrarily deep relative to their domain. Paths are generally structured as `/resource-type/{resource-id}`. Anywhere `{resource-id}` (e.g., `{task-id}` or `{report-id}`) occurs in a URI is to be understood as the URL-safe, unpadded base64 representation of the resource's identifier, which itself is usually 16 random bytes (some are 32, but https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/349 will normalize them to 16).
 

--- a/api-resources.md
+++ b/api-resources.md
@@ -1,0 +1,414 @@
+## Resources
+
+DAP is structured as an HTTP-based application with the following resources:
+
+- (TODO) Tasks
+- HPKE configurations
+- Reports
+- Aggregation jobs (and lists thereof)
+- Aggregate shares (and lists thereof)
+- Collections (and lists thereof)
+
+A resource's path is resolved relative to a server's base URL to construct a resource URI. Deployments may host resource paths arbitrarily deep relative to their domain. Paths are generally structured as `/resource-type/resource-id`. Anywhere `resource-id` (e.g., `task-id` or `report-id`) occurs in a URI is to be understood as the URL-safe, unpadded base64 representation of the resource's identifier, which itself is usually 16 random bytes (some are 32, but https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/349 will normalize them to 16).
+
+Some resources are owned by another resource, and so their URI will contain two identifiers. For instance, a report belongs to a task, so the URI is `[base]/tasks/task-id/reports/report-id`.
+
+Generally, if a resource supports the `GET` method, it also supports `HEAD`. The response to `HEAD` is exactly the same as `GET`, but the response contains no body.
+
+If an HTTP method is listed in a resource's required HTTP methods, implementations MUST provide responses as indicated. Otherwise, implementations MAY implement methods on resources however they wish, including returning an error like HTTP 405 Method Not Allowed.
+
+We use HTTP `PUT` requests for idempotent creation of resources. Server responses to `PUT` requests follow [RFC 9110 section 9.3.4](https://httpwg.org/specs/rfc9110.html#rfc.section.9.3.4).
+
+Finally, a quick reminder of some HTTP semantics: `GET` and `PUT` are idempotent (i.e., the same request may be made multiple times without changing state in the server more than once, and the response will be the same each time). `POST` is not idempotent. `GET` requests may not have bodies.
+
+We care a lot about idempotence because we need to account for cases where a client makes a request but never sees the response, and thus needs a way to recover from this state of uncertainty.
+
+### Tasks
+
+TODO: do we want a task resource that we can GET and PUT in the protocol? Does this collide with https://wangshan.github.io/draft-wang-ppm-dap-taskprov/draft-wang-ppm-dap-taskprov.html or https://github.com/divergentdave/draft-dcook-ppm-dap-interop-test-design?
+
+### HPKE configurations
+
+#### Path
+
+`/hpke_config[?task_id=task-id]`
+
+The `task_id` query parameter is optional, as described in https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.1.
+
+##### Alternatives
+
+An HPKE config has an ID, so we could use a path `hpke_configs/hpke-config-id`. However, a client should never need to get any HPKE config except for the "current" one, so does it make sense to expand the API surface with a path param for HPKE config ID?
+
+`GET /hpke_config` could redirect to `/hpke_config/current-hpke-config-id`, which would make this mostly transparent to clients, assuming they handle 3xx redirects properly.
+
+Instead of providing the task ID as a query parameter, we could also include it in the path, like `/tasks/task-id/hpke_config`, on the premise that the task ID is part of the resource's permanent identity. However, it's awkward to solve the global HPKE config case with this formulation. We could include a special task ID "global" so that clients could query `/tasks/global/hpke_config`.
+
+#### Representation
+
+Uses the existing [`struct HpkeConfig`](https://www.ietf.org/archive/id/draft-ietf-ppm-dap-02.html#section-4.3.1-6).
+
+```
+struct {
+  HpkeConfigId id;
+  HpkeKemId kem_id;
+  HpkeKdfId kdf_id;
+  HpkeAeadKdfId aead_id;
+  HpkePublicKey public_key;
+} HpkeConfig;
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+The response body is a `struct HpkeConfig` representing the `hpke_config`.
+
+### Reports
+
+#### Path
+
+`/tasks/task-id/reports/report-id`
+
+`report-id` uniquely identifies a report in a task. It is chosen by the client when uploading a report.
+
+#### Representation
+
+```
+struct {
+  Time time;
+  Extension extensions<0..2^16-1>;
+} ReportMetadata;
+
+struct {
+  ReportMetadata metadata;
+  opaque public_share<0..2^32-1>;
+  HpkeCiphertext encrypted_input_shares<1..2^32-1>;
+} Report;
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+The response body is a `struct Report` representing the report.
+
+##### PUT
+
+Idempotent upload of a report to an aggregator. The request body is a `struct Report`.
+
+This is analogous to DAP-02's `POST /upload`.
+
+### An aggregation job
+
+Only the helper supports this resource.
+
+#### Path
+
+`/tasks/task-id/aggregation_jobs/aggregation-job-id`
+
+`aggregation-job-id` uniquely identifies an aggregation job. It is chosen by the leader when it dispatches a job to the helper.
+
+#### Representation
+
+```
+enum {
+  continued(0),
+  finished(1),
+  failed(2),
+  (255),
+} PrepareStepState;
+
+struct {
+  ReportID report_id;
+  PrepareStepState prepare_step_state;
+  select (PrepareStep.prepare_step_state) {
+    case continued: opaque prep_msg<0..2^32-1>; /* VDAF preparation message */
+    case finished: Empty;
+    case failed: ReportShareError;
+  }
+} PrepareStep;
+
+struct {
+  u16 round;
+  PrepareStep prepare_steps<1..2^32-1>;
+} AggregateJob
+```
+
+See "POST", below, for explanation and justification of the `round` field.
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+The response body is a `struct AggregateJob` representing the current state of the reports in the job.
+
+##### PUT
+
+PUT to an aggregate job is how the leader creates an aggregate job in the helper. The body is an `AggregateJobPutReq`:
+
+```
+struct {
+  ReportMetadata metadata;
+  opaque public_share<0..2^32-1>;
+  HpkeCiphertext encrypted_input_share;
+} ReportShare;
+
+struct {
+  QueryType query_type;
+  select (PartialBatchSelector.query_type) {
+    case time_interval: Empty;
+    case fixed_size: BatchID batch_id;
+  };
+} PartialBatchSelector;
+
+struct {
+  opaque agg_param<0..2^16-1>;
+  PartialBatchSelector part_batch_selector;
+  ReportShare report_shares<1..2^32-1>;
+} AggregateJobPutReq;
+```
+
+If successful, the helper's response is a `struct AggregateJob` where `prepare_steps` contains the helper's first-round VDAF prepare messages for the report shares in `AggregateJobPutReq`, or errors if `vdaf.prepare` failed for any report.
+
+This is analogous to DAP-02's `POST /aggregate` with an `AggregateInitReq`.
+
+This request is idempotent, so if a helper receives multiple PUT requests for some aggregation job and the members of `AggregateJobPutReq` don't change, the helper can return 200 OK.
+
+The idea here is that all the values in `struct AggregateJobPutReq` never need to be transmitted again during the handling of an aggregate job, which is why the message is not `struct AggregateJob`.
+
+##### POST
+
+POST to an aggregate job is how the leader steps an aggregate job. The request body is a `struct AggregateJob` where `prepare_steps` contains the leader's current-round prepare messages, and `round` is the number of the current round. The response is a `struct AggregateJob` where `prepare_steps` contains the helper's next-round prepare messages. The response's `round` field will be one more than the request's `round`.
+
+We use a POST here because this request is _not_ idempotent. Suppose the leader sends `POST /tasks/task-id/aggregate_jobs/aggregation-job-id` where the body has `round = 1`, and that this is successfully handled by the helper. Besides generating the response, this will have the side effect of advancing the state in the helper to round 2. If the leader were to resend the `POST /tasks/task-id/aggregate_jobs/aggregation-job-id` with `round = 1`, then the request should be rejected by the helper, because it has advanced to the next round.
+
+This is analogous to DAP-02's `POST /aggregate` with an `AggregateContinueReq`.
+
+###### Context for the `round` field
+
+The `round` field is needed so that the leader can recover from a response being lost. Suppose a 2-round VDAF is being executed, and that the leader does `PUT /tasks/task-id/aggregate_jobs/aggregation-job-id` and that request succeeds, so the helper responds with its first-round prepare messages. Then, the leader does `POST /tasks/task-id/aggregate_jobs/aggregation-job-id` with the first-round broadcast prepare message, but the helper's response gets lost during network transit.
+
+If the helper received the `POST` and advanced its state to the second round, then the leader should do `GET /tasks/task-id/aggregate_jobs/aggregation-job-id` so it can compute the second round broadcast message and then do `POST /tasks/task-id/aggregate_jobs/aggregation-job-id` to have the helper move to the finished state. If the helper did not receive the `POST`, then the leader should re-send the first-round broadcast prepare message.
+
+But in DAP-02, the leader has no way to know what happened in the helper, leaving it unable to recover from this state. Adding a `round` field to the `AggregateJob` message enables the leader to reliably and idempotently find out what state the helper is in by doing `GET /tasks/task-id/aggregate_jobs/aggregation-job-id`, and then taking the appropriate next step.
+
+##### DELETE
+
+Instructs the helper to abandon the aggregate job and allows it to discard all state related to it.
+
+Requiring this would solve https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/241
+
+### Aggregation jobs
+
+Only the helper supports this resource.
+
+#### Path
+
+`/tasks/task-id/aggregation_jobs`
+
+#### Representation
+
+A paginated list of aggregation jobs for the task.
+
+```
+struct {
+  u64 page;
+  AggregateJob aggregate_jobs<0..2^16-1>
+} AggregationJobList
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+The request takes an optional query parameter for the page. The response body is a `struct AggregationJobList`.
+
+### An aggregate share
+
+Only the helper supports this resource.
+
+#### Path
+
+`/tasks/task-id/aggregate_shares/aggregate-share-id`
+
+`aggregate-share-id` uniquely identifies an aggregate share. It is chosen by the leader when it requests an aggregate share by the helper.
+
+#### Representation
+
+```
+struct {
+  HpkeCiphertext encrypted_aggregate_share;
+} AggregateShare;
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+If the aggregate share is available, the result is a `struct AggregateShare`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such aggregate share is known to the helper.
+
+##### PUT
+
+PUT to an aggregate share resource is how the leader instructs the helper to compute aggregate shares. The request is an idempotent PUT, because if an aggregate share with the provided ID already exists, its representation can be returned by the helper without further state mutation.
+
+The body of the request is an `AggregateShareReq`:
+
+```
+struct {
+  QueryType query_type;
+  select (BatchSelector.query_type) {
+    case time_interval: Interval batch_interval;
+    case fixed_size: Empty;
+  };
+} BatchSelector;
+
+struct {
+  BatchSelector batch_selector;
+  opaque agg_param<0..2^16-1>;
+  uint64 report_count;
+  opaque checksum[32];
+} AggregateShareReq;
+```
+
+If successful, the response from the helper is a `struct AggregateShare`. That same share may later be obtained by a GET request on the resource.
+
+This is analogous to DAP-02's `POST /aggregate_share`.
+
+###### A note on `BatchSelector.fixed_size`
+
+In DAP-02, a `BatchSelector` with `query_type = fixed_size` contains a `BatchID`. In this API, the batch ID hoisted up into the resource URI. This implies that `time_interval`-type queries now also have a batch ID, chosen by the leader. While aggregate shares will often (always?) be 1:1 with collections, the IDs do not have to match.
+
+Note also that `AggregateShareReq` should use a `Query` (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/366).
+
+TODO: timg to read more about chunky DAP and think about how it intersects with this proposal, especially https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/342
+
+##### DELETE
+
+Instructs the helper to abandon the aggregate share and allows the helper to discard all state related to it. This is akin to DELETE on a collection for the leader.
+
+### Aggregate shares
+
+Only the helper supports this resource.
+
+#### Path
+
+`/tasks/task-id/aggregate_shares`
+
+#### Representation
+
+A paginated list of aggregation jobs for the task.
+
+```
+struct {
+  u64 page;
+  AggregateShare aggregate_shares<0..2^16-1>
+} AggregateShareList
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+The request takes an optional query parameter for the page. The response body is a `struct AggregateShareList`.
+
+### A collection
+
+Only the leader supports this resource.
+
+#### Path
+
+`/tasks/task-id/collections/collection-id`
+
+`collection-id` uniquely identifies a collection. It is chosen by the collector when it POSTs to the resource.
+
+#### Representation
+
+```
+struct {
+  PartialBatchSelector part_batch_selector;
+  uint64 report_count;
+  HpkeCiphertext encrypted_agg_shares<1..2^32-1>;
+} Collection;
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+If the collection is available, the response body is a `struct Collection`. Otherwise the server can return something like HTTP 202 Accepted to indicate it's not ready yet, or HTTP 404 if no such aggregate share request is known to the server.
+
+This is analogous to DAP-02's `GET` on a collect job URI.
+
+##### PUT
+
+PUT to a collection resource is how the collector instructs the leader to assemble the aggregate shares. The request is an idempotent PUT, because if a collection with the provided ID already exists, its representation can be returned by the helper without further state mutation.
+
+The request body is a `CollectReq`:
+
+```
+struct {
+  QueryType query_type;
+  select (Query.query_type) {
+    case time_interval: Interval batch_interval;
+    case fixed_size: Empty;
+  }
+} Query;
+
+struct {
+  Query query;
+  opaque agg_param<0..2^16-1>; /* VDAF aggregation parameter */
+} CollectReq;
+```
+
+If successful, the response from the helper is a `struct Collection`. That same share may later be obtained by a GET request on the resource.
+
+This is analogous to DAP-02's `POST /collect`.
+
+###### A note on `Query.fixed_size`
+
+`struct Query` is essentially identical to `struct BatchSelector`, so the note about `BatchSelector.fixed_size` from `PUT aggregate_share` applies here, except that a collection's ID is chosen by the collector.
+
+##### DELETE
+
+Instructs the leader to abandon the collection and allows the leader to discard all state related to it. This is akin to DELETE on an aggregate share for the helper (indeed, the leader might send a DELETE to the helper's aggregate share resource after its corresponding collection is deleted).
+
+This is analogous to DAP-02's `DELETE` on a collect job URI.
+
+#### Alternatives: `collection-id`, `PUT` vs. `POST` and idempotence?
+
+This proposal introduces the notion of a `collection-id`, which is chosen by the collector when it sends `CollectReq` to helper. In DAP-02, a collection is already uniquely identified by the combination of the aggregation parameter and the query, meaning we can get by without `collection-id`. Let's sketch out what the API would look like so we can weigh pros and cons.
+
+`POST /tasks/task-id/collections`
+
+The body is a `CollectReq`, defined as above. The request method is `POST` instead of `PUT` because I don't think this request can be idempotent. Let's say a collector makes a time interval query over some interval _i_ and it is received by the leader at time _t1_. At _t1_, the leader has _n1_ reports that fall into the interval _i_. Then, suppose at least one more report that falls into _i_ arrives and the leader and helper prepare it. Then, at _t2 > t1_, the collector sends a query with the same interval _i_ again.
+
+Should the leader serve up the results it computed at time _t1_? Or should it make a new collection, consuming another unit of max batch query, that includes the reports that arrived and were prepared between _t1_ and _t2_?
+
+If collections are identified by `collection-id`, then there's no ambiguity: the collector can poll `GET /tasks/task-id/collections/collection-id` to obtain the same collection over and over again. `PUT /tasks/task-id/collections/collection-id` with the same `collection-id` is also unambiguous, and if the collector wants to make a new query with the same interval, it can choose a new `collection-id` and `PUT` that, which the leader will service if the task's parameters allow it.
+
+The cons of `collection-id` is that an aggregation parameter and a `struct Query` don't uniquely identify a collection. So if a collector wants to find out if there's an existing collect job that meets its parameter, it has to enumerate all of them using `GET /tasks/task-id/collections`. We could improve this either with [HTTP QUERY](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html) or query params on `GET /tasks/task-id/collections`.
+
+### Collections
+
+Only the leader supports this resource.
+
+#### Path
+
+`/tasks/task-id/collections`
+
+#### Representation
+
+A paginated list of collections for the task.
+
+```
+struct {
+  u64 page;
+  Collection collections<0..2^16-1>
+} CollectionList
+```
+
+#### Required HTTP methods
+
+##### GET/HEAD
+
+The request takes an optional query parameter for the page. The response body is a `struct CollectionList`.

--- a/api-resources.md
+++ b/api-resources.md
@@ -20,7 +20,7 @@ We use HTTP `PUT` requests for idempotent creation of resources. Server response
 
 Finally, a quick reminder of some HTTP semantics: `GET` and `PUT` are idempotent (i.e., the same request may be made multiple times without changing state in the server more than once, and the response will be the same each time). `POST` is not idempotent. `GET` requests may not have bodies.
 
-We care a lot about idempotence because we need to account for cases where a client makes a request but never sees the response, and thus needs a way to recover from this state of uncertainty.
+We care a lot about idempotence because we need to account for cases where an HTTP client (e.g., the collector obtaining aggregate shares from the leader, or the leader driving the aggregation sub-protocol in the helper) makes a request but never sees the response, and thus needs a way to recover from this state of uncertainty.
 
 ### HPKE configurations
 


### PR DESCRIPTION
This is a sketch of a resource oriented API for DAP. It's presented
separately from the main body of protocol text because before taking on
the work of integrating it in, I want to begin a discussion about this
proposal, leading up to a presentation at IETF 115.

The objectives are to refactor the DAP API into a resource-oriented API
more in line with conventional HTTP semantics and REST. In particular, I
am trying to pay close attention to idempotence and ensuring that
protocol participants can recover gracefully from network messages being
lost.

Designing the API around resources identified by a URI also simplifies
message handling: servers no longer need to parse the first part of a
message to get a task ID to then figure out what the rest of the message
contains, because now things like a task ID are in a resource's path.

We also should be able to write less protocol text, because if all of
our resources are boring HTTP nouns, then the usual semantics for things
like HTTP 202 Accepted, 3xx redirects or 404 Not Found apply.

I do _not_ introduce an ACME style API directory, because I'm not
convinced that it is appropriate to introduce an extra level of
indirection for DAP API requests, which are going to be more performance
sensitive than ACME.

I also deliberately avoid ACME's POST-as-GET requests, because our
experience at Let's Encrypt has been that those make it hard to cache
responses, because CDNs don't expect POST results to be cacheable.

I've put this up on GitHub as a PR so that it's out in public and folks
can leave comments inline reasonably gracefully, although I don't intend
to ever merge this.

Relevant to #278