### PR TITLE
Introduce resource oriented API

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1198,7 +1198,7 @@ enum {
 struct {
   opaque agg_param<0..2^32-1>;
   PartialBatchSelector part_batch_selector;
-  ReportShares report_shares<1..2^32-1>;
+  ReportShare report_shares<1..2^32-1>;
 } AggregationJobInitializeReq;
 ~~~
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -570,7 +570,7 @@ struct {
 /* An ID used to uniquely identify a report in the context of a DAP task. */
 uint8 ReportID[16];
 
-/* Metadata describing a report. */
+/* Public metadata describing a report. */
 struct {
   ReportID report_id;
   Time time;
@@ -816,9 +816,6 @@ The `HpkeConfigList` structure contains one or more `HpkeConfig` structures in
 decreasing order of preference. This allows a server to support multiple HPKE
 configurations simultaneously.
 
-[TODO: Allow aggregators to return HTTP status code 403 Forbidden in deployments
-that use authentication to avoid leaking information about which tasks exist.]
-
 Aggregators SHOULD allocate distinct `id` values for each `HpkeConfig` in an
 `HpkeConfigList`. The RECOMMENDED strategy for generating these values is via
 rejection sampling, i.e., to randomly select an `id` value repeatedly until it
@@ -871,7 +868,8 @@ shares and computing the public share using the VDAF's
 `measurement_to_input_shares` algorithm ({{!VDAF, Section 5.1}}):
 
 ~~~
-(public_share, input_shares) = VDAF.measurement_to_input_shares(measurement)
+(public_share, input_shares) =
+  VDAF.measurement_to_input_shares(measurement)
 ~~~
 
 [TODO: in VDAF-04, `measurement_to_input_shares` will take a nonce argument, for
@@ -930,9 +928,7 @@ struct {
   order to ensure that that the timestamp cannot be used to link a report back
   to the Client that generated it.
 
-* `public_share` is the `public_share` output by
-  `VDAF.measurement_to_input_shares`. Note that some VDAFs, like Prio3, have an
-  empty public share (see {{!VDAF}}).
+* `public_share` is the `public_share` output by the VDAF sharding algorithm.
 
 * `encrypted_input_shares` is the encrypted input share of each of the
    Aggregators. The order of the encrypted input shares appear MUST match the
@@ -985,7 +981,7 @@ Each `PlaintextInputShare` carries a list of extensions that Clients use to
 convey additional information to the Aggregator. Some extensions might be
 intended for all Aggregators; others may only be intended for a specific
 Aggregator. For example, a DAP deployment might use some out-of-band mechanism
-for an Aggregator to verify that `Reports` come from authenticated Clients. It
+for an Aggregator to verify that reports come from authenticated Clients. It
 will likely be useful to bind the extension to the input share via HPKE
 encryption.
 
@@ -1058,7 +1054,7 @@ Specifically:
 
 * Some VDAFs (e.g., Prio3) allow the Leader to start aggregating reports
   proactively before all the reports in a batch are received. Others (e.g.,
-  Poplar1) cannot be prepared until the collector provides the aggregation
+  Poplar1) cannot be prepared until the Collector provides the aggregation
   parameter.
 
 * Processing the reports -- especially validating them -- may require multiple
@@ -1108,7 +1104,7 @@ The Leader begins an aggregation job by choosing a set of candidate reports that
 pertain to the same DAP task. The Leader can prepare many reports in parallel by
 concurrently creating multiple aggregation jobs. After choosing the set of
 candidates, the Leader begins aggregation by splitting each report into "report
-shares", one for each aggregator. The Leader and Helpers then run the aggregate
+shares", one for each Aggregator. The Leader and Helpers then run the aggregate
 initialization flow to accomplish two tasks:
 
 1. Recover report shares and determine which are invalid.

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1040,7 +1040,7 @@ of relevant: issue #89]]
 Once a set of Clients have uploaded their reports to the Leader, the Leader can
 send them to the Helpers to be verified and aggregated. Verification of a set of
 reports is referred to as an aggregation job. Each aggregation job is associated
-with exactly one DAP task, and a DAP task will have many aggregation jobs. In
+with exactly one DAP task, and a DAP task can have many aggregation jobs. In
 order to enable the system to handle very large batches of reports, this process
 can be parallelized by dividing the preparation of a batch's reports into
 multiple aggregation jobs.
@@ -1100,7 +1100,7 @@ each valid input report share into an output share:
 ### Aggregation Job Resource {#aggregation-job-resource}
 
 Executing the aggregation flow consists of the Leader interacting with the
-Helper's aggregate job resource. Only the Helper supports this resource.
+Helper's aggregation job resource. Only the Helper supports this resource.
 
 #### Representation {#aggregation-job-representation}
 
@@ -1116,7 +1116,6 @@ struct {
   ReportID report_id;
   PrepareStepState prepare_step_state;
   select (PrepareStep.prepare_step_state) {
-    case start: ReportShare;
     case continued: opaque prep_msg<0..2^32-1>;
     case finished: Empty;
     case failed: ReportShareError;
@@ -1397,9 +1396,9 @@ three outputs:
    `(prep_state, prep_msg)`, in which case the Helper replies to the leader with
    `PrepareStep` in the `continued` state containing `prep_msg`.
 
-After computing each report share's preparation state and prepare message, the
-Helper SHOULD store them, tagged with the round they were computed in, so that
-the Leader can recover from losing the Helper's response.
+Helpers SHOULD store the most recent preparation state and prepare messages for
+each report share, tagged with the round they were computed for, so that the
+Aggregators may recover from the Leader losing the Helper's response.
 
 If the `round` in the Leader's request is equal to the Helper's current round
 (i.e., this is not the first time the Leader has sent this request), then the
@@ -1420,8 +1419,8 @@ of the Helper's `prepare_steps` MUST match that of the Leader's.
 ##### DELETE `/tasks/{task-id}/aggregation_jobs/{aggregation-job-id}` {#aggregation-job-delete}
 
 Indicates to the Helper that it MAY abandon the aggregation job and discard all
-state related to it. Whether or not it deletes any data, the Helper MUST respond
-with status 204 No Content.
+state related to it. If the Helper successfully handles this request, it MUST
+respond with status 204 No Content.
 
 Helpers MAY delete aggregation jobs and their related state ahead of an explicit
 DELETE request, as part of a garbage collection scheme. DELETE requests to an

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1680,7 +1680,7 @@ problem document as described in {{errors}}.
 The Leader MAY respond with 204 No Content for requests to a collection if the
 results have been deleted due to age.
 
-###### A note on idempotence
+###### A Note on Idempotence
 
 The reason we use a POST instead of a GET to poll the state of a collection is
 because of the fixed-size query mode (see {{fixed-size-query}}). Collectors may

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -517,7 +517,7 @@ DAP is structured as an HTTP application consisting of three major interactions
 or sub-protocols:
 
 * Uploading reports from the client to the aggregators, using the HPKE
-  configuration ({{hpke-config-resource}}) and report ({{report-resource}})
+  configuration ({{hpke-configs-resource}}) and report ({{report-resource}})
   resources, as described in {{upload-flow}}.
 * Computing the aggregate over sets of reports, using the aggregation job
   resource ({{aggregation-job-resource}}), as described in {{aggregate-flow}}.
@@ -772,12 +772,12 @@ individual shares to each Helper. The upload sub-protocol involves the HPKE
 configurations ({{hpke-config-resource}}) and reports ({{report-resource}})
 resources.
 
-### HPKE Configuration Resource {#hpke-config-resource}
+### HPKE Configurations Resource {#hpke-configs-resource}
 
-Before the client can upload its report to the leader, it must know the HPKE
-configuration of each aggregator. See {{compliance}} for information on HPKE
-algorithm choices. Clients retrieve the HPKE configuration from each aggregator
-by accessing the HPKE configuration resource.
+Before the client can upload its report to the leader, it must know each
+Aggregator's supported HPKE configurations. See {{compliance}} for information
+on HPKE algorithm choices. Clients retrieve the HPKE configurations from each
+Aggregator by accessing the HPKE configurations resource.
 
 #### Required methods
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -755,7 +755,7 @@ In addition, in order to facilitate the aggregation and collect protocols, each
 of the aggregators is configured with following parameters:
 
 * `collector_config`: The {{!HPKE=RFC9180}} configuration of the collector
-  (described in {{hpke-config-resource}}); see {{compliance}} for information
+  (described in {{hpke-configs-resource}}); see {{compliance}} for information
   about the HPKE configuration algorithms.
 * `vdaf_verify_key`: The VDAF verification key shared by the aggregators. This
   key is used in the aggregation sub-protocol ({{aggregate-flow}}). [OPEN ISSUE:
@@ -769,7 +769,7 @@ Finally, the collector is configured with the HPKE secret key corresponding to
 
 Clients periodically upload reports to the Leader, which then distributes the
 individual shares to each Helper. The upload sub-protocol involves the HPKE
-configurations ({{hpke-config-resource}}) and reports ({{report-resource}})
+configurations ({{hpke-configs-resource}}) and reports ({{report-resource}})
 resources.
 
 ### HPKE Configurations Resource {#hpke-configs-resource}
@@ -1824,12 +1824,12 @@ computed above and `encrypted_aggregate_share.ciphertext` is the ciphertext
 `encrypted_agg_share` computed above.
 
 After receiving the Helper's response, the Leader uses the HpkeCiphertext to
-respond to a collect request (see {{collection-resource}}).
+respond to a collect request (see {{collect-job-resource}}).
 
 After issuing an aggregate-share request for a given query, it is an error for
 the Leader to issue any more aggregation jobs for additional reports that
 satisfy the query. These reports will be rejected by Helpers as described in
-{{agg-init}}.
+{{aggregation-job-put}}.
 
 [[OPEN ISSUE: do we need a DELETE request on aggregate shares? If so, do we
 need an aggregate-share-id to construct a URI for an aggregate share?]]
@@ -2472,7 +2472,7 @@ the input shares and defeat privacy.
 This specification defines the following protocol messages, along with their
 corresponding media types types:
 
-- HpkeConfigList {{hpke-config-resource}}: "application/dap-hpke-config-list"
+- HpkeConfigList {{hpke-configs-resource}}: "application/dap-hpke-config-list"
 - Report {{report-resource}}: "application/dap-report"
 - AggregationJobInitializeReq {{aggregate-flow}}: "application/dap-aggregation-job-initialize-req"
 - AggregationJob {{aggregate-flow}}: "application/dap-aggregation-job"

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -568,7 +568,7 @@ struct {
 } Interval;
 
 /* An ID used to uniquely identify a report in the context of a DAP task. */
-uint8 ReportID[16];
+opaque ReportID[16];
 
 /* Public metadata describing a report. */
 struct {
@@ -1422,7 +1422,7 @@ check on their state. Only the Helper supports this resource.
 ##### Representation {#aggregation-job-representation}
 
 ~~~
-uint8 AggregationJobId[16];
+opaque AggregationJobId[16];
 
 struct {
   ReportMetadata metadata;

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1362,7 +1362,10 @@ state containing the corresponding `inbound` prepare message.
 ###### Helper Continuation
 
 If the Helper does not recognize the task ID, then it MUST abort with error
-`unrecognizedTask`.
+`unrecognizedTask`. If the Helper does not recognize the aggregation job, then
+it MUST abort with error `unrecognizedAggregationJob`. This could occur because
+the aggregation job never existed, but also if it was deleted (see
+{{aggregation-job-delete}}).
 
 Otherwise, for each `PrepareStep` received from the Leader in
 `AggregationJob.prepare_steps`, the Helper checks
@@ -1414,10 +1417,15 @@ of the Helper's `prepare_steps` MUST match that of the Leader's.
 
 [[OPEN ISSUE: consider relaxing this ordering constraint. See issue#217.]]
 
-##### DELETE `/tasks/{task-id}/aggregation_jobs/{aggregation-job-id}`
+##### DELETE `/tasks/{task-id}/aggregation_jobs/{aggregation-job-id}` {#aggregation-job-delete}
 
-Once an aggregation job is deleted, the Helper MAY abandon it and discard all
-state related to it (e.g., report shares, prepare messages, preparation state).
+Indicates to the Helper that it MAY abandon the aggregation job and discard all
+state related to it. Whether or not it deletes any data, the Helper MUST respond
+with status 204 No Content.
+
+Helpers MAY delete aggregation jobs and their related state ahead of an explicit
+DELETE request, as part of a garbage collection scheme. DELETE requests to an
+already-deleted aggregation job SHOULD yield a 204 No Content response.
 
 #### Input Share Decryption {#input-share-decryption}
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1191,7 +1191,7 @@ abort?]]
 #### Input Share Decryption {#input-share-decryption}
 
 Each report share has a corresponding task ID, report metadata (report ID and
-timestamp), the public share sent to each Aggregator, and the recipient's
+timestamp), a public share sent to each Aggregator, and the recipient's
 encrypted input share. Let `task_id`, `metadata`, `public_share`, and
 `encrypted_input_share` denote these values, respectively. Given these values,
 an aggregator decrypts the input share as follows. First, it constructs an

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1374,7 +1374,7 @@ continue being prepared. If the report share is in state `failed` or `finished`,
 then the Helper marks the report as failed with error `unrecognized_message`.
 
 If the state is `continued`, then the Helper continues with preparation for the
-report share. The Helper MUST check its current preparation state against the
+report share. The Helper MUST check its current round against the
 Leader's `AggregationJob.round` value. If the Leader is one round ahead of the
 Helper, then the Helper can combine the Leader's prepare message and the
 Helper's current preparation state (`prep_state`) as follows:

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1615,8 +1615,7 @@ Collector, as described in {{collection-resource}}. The structure of this URI is
 not specified, so implementations may use any unique identifier they wish for
 collections.
 
-The Leader then asynchronously begins working with the Helper to prepare the
-input shares satisfying the query (or continues this process, depending on the
+The Leader then asynchronously begins working with the Helper to aggregate the reports satisfying the query (or continues this process, depending on the
 VDAF) as described in {{aggregate-flow}}, and then invokes the aggregate share
 request flow described in {{aggregate-share-resource}} to gather aggregate
 shares from Helpers.

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -781,7 +781,7 @@ by accessing the HPKE configuration resource.
 
 #### Required methods
 
-##### GET `/hpke_config[?task_id={task-id}]`
+##### GET `/hpke_configs[?task_id={task-id}]`
 
 An aggregator is free to use different HPKE configurations for each task with
 which it is configured. Clients MAY specify a query parameter `task_id` whose


### PR DESCRIPTION
Changes the DAP API to orient the upload, aggregate and collect sub-protocols around some HTTP resources, namely:

Upload:
 - HPKE configurations
 - Reports

Aggregate:
 - Aggregation jobs

Collect:
 - Collections
 - Aggregate shares

There's a lot of change here, most of which is changing the spelling of HTTP endpoints from e.g. `POST /upload` to
`PUT /tasks/{task-id}/reports/{report-id}`. But there are some more important improvements made here:

 - move some identifiers from message bodies into resource paths, removing the need to partially parse messages to get task ID
 - aggregation job messages now contain a `round` field to allow aggregators to recover from message loss

The other big goal here is to make better use of HTTP primitives and conventions. However, it's important not to get too precious about this: we expect that anything using this API is a DAP implementation rather than a generic HTTP client like a web browser, so it doesn't matter that much if we choose exactly the right HTTP method, because ultimately DAP gets to dictate the semantics of any message.

Resolves #278 