### PR TITLE
DAP-04 text cleanups

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1417,8 +1417,13 @@ the `ReportShareError`:
   - For any other error, the leader marks the report as failed, removes it from
     the candidate report set and does not process it further.
 
-If the type is `finished`, then the leader aborts with `unrecognizedMessage`. If
-the type is `continued`, then the leader proceeds as follows.
+If the type is `finished` and the Leader's preparation of this report share is
+also finished, then the report share is aggregated and can now be collected (see
+{{collect-flow}}). If the Leader is not finished, then the report cannot be
+processed further and MUST be removed from the candidate set.
+
+If the Helper's `PrepareStep` is of type `continued`, then the Leader proceeds
+as follows.
 
 Let `leader_outbound` denote the leader's prepare message and `helper_outbound`
 denote the helper's. The leader computes the next state transition as follows:

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -850,8 +850,18 @@ task ID and report "metadata". The metadata consists of the following fields:
   it.
 
 To generate a report, the Client begins by sharding its measurement into input
-shares as specified by the VDAF. It then wraps each input share in the following
-structure:
+shares and the public share using the VDAF's sharding algorithm
+({{!VDAF, Section 5.1}}):
+
+~~~
+(public_share, input_shares) =
+  VDAF.measurement_to_input_shares(measurement)
+~~~
+
+[TODO: in VDAF-04, `measurement_to_input_shares` will take a nonce argument, for
+which we will use the report ID #394]
+
+The Client then wraps each input share in the following structure:
 
 ~~~
 struct {

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1059,9 +1059,6 @@ Aggregate request (continued, Job = M) ------------------>  | 11-20
 {: #aggregation-flow-illustration title="Aggregation Flow (batch size=20).
 Multiple aggregation flows can be executed at the same time."}
 
-[OPEN ISSUE: Should there be an indication of whether a given aggregate request
-is a continuation of a previous sub-batch?]
-
 The aggregation flow can be thought of as having three phases for transforming
 each valid input report share into an output share:
 


### PR DESCRIPTION
# Stacked on #398

This PR includes several text cleanups previously folded into #395:

- The upload section explicitly describes the call to `VDAF.measurement_to_input_shares`
- An obsolete TODO in the aggregation section is removed
- Text that incorrectly instructed leaders to abort if the helper finishes aggregation is corrected.