### PR TITLE
Add `interval` to struct `Collection`

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1617,6 +1617,7 @@ job with HTTP status code 200 OK and a body consisting of a `Collection`:
 struct {
   PartialBatchSelector part_batch_selector;
   uint64 report_count;
+  Interval interval;
   HpkeCiphertext encrypted_agg_shares<1..2^32-1>;
 } Collection;
 ~~~
@@ -1630,6 +1631,12 @@ This structure includes the following:
   [OPEN ISSUE: What should the Collector do if the query type doesn't match?]
 
 * The number of reports included in the batch.
+
+* The smallest interval of time that contains the timestamps of all reports
+  included in the batch, such that the interval's start and duration are
+  both multiples of the task's `time_precision` parameter. Note that in the case
+  of a `time_interval` type query (see {{query}}), this interval can be smaller
+  than the one in the corresponding `CollectionReq.query`.
 
 * The vector of encrypted aggregate shares. They MUST appear in the same order
   as the aggregator endpoints list of the task parameters.


### PR DESCRIPTION
The Leader now informs the Collector of what time interval is spanned by the reports aggregated into a collection, regardless of the query type. This is particularly useful for fixed size tasks as otherwise a Collector can only guess at the report times based on the timing of collection requests, but also useful in time interval tasks since the aggregated reports could span a *smaller* interval that what was requested (e.g., if the collector requested a one hour time interval, but reports only arrived during minutes 30-40 of that hour).

Resolves #397