### PR TITLE
Forbid `AggregationJobContinueReq.round = 0`

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1556,6 +1556,9 @@ three outputs:
 After stepping each state, the Helper advances its aggregation job to the
 Leader's `AggregationJobContinueReq.round`.
 
+If the `round` in the Leader's request is 0, then the Helper MUST abort with an
+error of type `unrecognizedMessage`.
+
 If the `round` in the Leader's request is equal to the Helper's current round
 (i.e., this is not the first time the Leader has sent this request), then the
 Helper responds with the current round's prepare messages. The Helper SHOULD


### PR DESCRIPTION
During implementation of round skew recovery in Janus ([1]), we noticed that the specification is unclear about what the helper should do if `AggregationJobContinueReq.round = 0`. This commit clarifies that this value is illegal and should be rejected.

[1]: https://github.com/divviup/janus/pull/1091

===

After handling `AggregationJobInitReq`, the helper's aggregation job will be on round 0, because the helper is waiting for the leader to send it the first-round broadcast prepare message, with which helper will advance to round 1. So before this commit, the applicable statement in the text was:

> If the `round` in the Leader's request is equal to the Helper's current round
> (i.e., this is not the first time the Leader has sent this request), then the
> Helper responds with the current round's prepare messages. The Helper SHOULD
> verify that the contents of the `AggregationJobContinueReq` are identical to the
> previous message (see {{aggregation-round-skew-recovery}}).

Which means the helper would have to retransmit its first-round prepare shares, which it had previously sent in response to `AggregationJobInitReq`. This is implementable but weird: if the leader dropped the response to `AggregationJobInitReq`, then it should recover by re-sending it (I just wasted months of my life making sure that PUT to an aggregation job is idempotent). It seems simpler to me to just forbid round to be 0.