### PR TITLE
Idempotent aggregate shares endpoint

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2039,6 +2039,11 @@ struct {
 computed above and `encrypted_aggregate_share.ciphertext` is the ciphertext
 `encrypted_agg_share` computed above.
 
+The helper's handling of this request MUST be idempotent. That is, if multiple
+identical, valid `AggregateShareReq`s are received, they should all yield the
+same response while only consuming one unit of the task's
+`max_batch_query_count` (see {{batch-validation}}).
+
 After receiving the Helper's response, the Leader uses the HpkeCiphertext to
 finalize a collection job (see {{collect-finalization}}).
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2039,7 +2039,7 @@ struct {
 computed above and `encrypted_aggregate_share.ciphertext` is the ciphertext
 `encrypted_agg_share` computed above.
 
-The helper's handling of this request MUST be idempotent. That is, if multiple
+The Helper's handling of this request MUST be idempotent. That is, if multiple
 identical, valid `AggregateShareReq`s are received, they should all yield the
 same response while only consuming one unit of the task's
 `max_batch_query_count` (see {{batch-validation}}).


### PR DESCRIPTION
Require that the helper's `/tasks/{task-id}/aggregate_shares` endpoint be idempotent.

Resolves #226