### PR TITLE
Be explicit about task param immutability

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -747,6 +747,10 @@ of the Aggregators is configured with following parameters:
 Finally, the Collector is configured with the HPKE secret key corresponding to
 `collector_hpke_config`.
 
+A task's parameters are immutable for the lifetime of that task. The only way to
+change parameters or to rotate secret values like collector HPKE configuration
+and the VDAF verification key is to define a new task.
+
 ## Resource URIs
 
 DAP is defined in terms of "resources", such as reports ({{upload-flow}}),


### PR DESCRIPTION
I've satisfied myself by reading the document that nothing implies that task params can be mutated or rotated, so all we need is a paragraph explicitly stating this.

Resolves #237