### PR TITLE
Use `Empty` for empty variants

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -578,6 +578,9 @@ struct {
   opaque enc<1..2^16-1>;     /* encapsulated HPKE key */
   opaque payload<1..2^32-1>; /* ciphertext */
 } HpkeCiphertext;
+
+/* Represent a zero-length byte string. */
+struct {} Empty;
 ~~~
 
 DAP uses the 16-byte `ReportID` as the nonce parameter for the VDAF
@@ -621,6 +624,7 @@ struct {
   FixedSizeQueryType query_type;
   select (query_type) {
     by_batch_id: BatchID batch_id;
+    current_batch: Empty;
   }
 } FixedSizeQuery;
 
@@ -1247,6 +1251,7 @@ follows:
 struct {
   QueryType query_type;
   select (PartialBatchSelector.query_type) {
+    case time_interval: Empty;
     case fixed_size: BatchID batch_id;
   };
 } PartialBatchSelector;
@@ -1376,6 +1381,7 @@ struct {
   PrepareRespState prepare_resp_state;
   select (PrepareResp.prepare_resp_state) {
     case continue: opaque payload<0..2^32-1>;
+    case finished: Empty;
     case reject:   PrepareError prepare_error;
   };
 } PrepareResp;


### PR DESCRIPTION
Define `struct {} Empty` and use it wherever we have an enum variant with no bytes following it.

This was removed in c5868ea9854cef7379cef6712aa2d702888f01c9. Our thinking was that unlisted variants implicitly have no bytes following them. This seems like a logical interpretation based on the following example (from RFC8446, Appendix B.3):

```
      struct {
          HandshakeType msg_type;    /* handshake type */
          uint24 length;             /* bytes in message */
          select (Handshake.msg_type) {
              case client_hello:          ClientHello;
              case server_hello:          ServerHello;
              case end_of_early_data:     EndOfEarlyData;
              case encrypted_extensions:  EncryptedExtensions;
              case certificate_request:   CertificateRequest;
              case certificate:           Certificate;
              case certificate_verify:    CertificateVerify;
              case finished:              Finished;
              case new_session_ticket:    NewSessionTicket;
              case key_update:            KeyUpdate;
          };
      } Handshake;
```

`HandshakeType` defines variants that are not listed here; presumably it is because there are no more bytes to read following the `select` statement in these variants.

However, as explained at the top of Appendix B, those variants suffixed by `RESERVED` are defined for backwards compatibiliby only and are not meant to be sent on the wire in TLS 1.3. Thus if the peer sends one of these variants, the host is supposed to treat it as a fatal error.

Similarly for the `message_hash` variant: This is used to construct an input to a hash function, but is never used in a message written to the wire.