### PR TITLE
fix formatting of expanded URL

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -797,10 +797,8 @@ to the following rules:
   specified in {{Sections 5 and 3.2 of !RFC4648}}.
 
 For example, resource URI `{leader}/tasks/{task-id}/reports` might be expanded
-into:
-~~~
-https://example.com/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/reports
-~~~
+into
+`https://example.com/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/reports`
 
 ## Uploading Reports {#upload-flow}
 


### PR DESCRIPTION
This piece of Markdown is awkward when rendered into text (see [DAP-05](https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap-05#section-4.3-3)). With this change, the resulting rendered text is:

```
   For example, resource URI {leader}/tasks/{task-id}/reports might be
   expanded into https://example.com/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-
   QIGYvg_RsByGec/reports
```