### PR TITLE
Re-allow creation of aggregation jobs after collection job created.

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1934,10 +1934,8 @@ collection job or tries again later, depending on which requirement in
 {{batch-validation}} was not met. If the Leader has a pending aggregation job
 that overlaps with the batch for the collection job, the Leader MUST first
 complete the aggregation job before proceeding and requesting an aggregate share
-from the Helper. After the collection job has been created, the Leader MUST NOT
-schedule new aggregation jobs that overlap with the batch for the collection
-job. This avoids a race condition between aggregation and collection jobs that
-can yield trivial batch mismatch errors.
+from the Helper. This avoids a race condition between aggregation and collection
+jobs that can yield trivial batch mismatch errors.
 
 Once both aggregate shares are successfully obtained, the Leader responds to
 subsequent HTTP POST requests to the collection job with HTTP status code 200 OK


### PR DESCRIPTION
This wording was introduced by #512, please see that PR for context. Removing this sentence is desirable for a few reasons:

* For any VDAFs which require an aggregation parameter before aggregation can begin, or which require multiple aggregations with differing aggregation parameters, a collection job must be received before aggregation jobs can be created.
* Even for VDAFs which do not use an aggregation parameter, implementations may wish to use a more flexible job-scheduling strategy. For example, Janus will still create new aggregation jobs while awaiting completion of existing aggregation jobs, even if a collection job has been received for the relevant batch.
* I believe the technical requirement here is captured by the preceding sentence, i.e. aggregation jobs must be completed before an aggregate share request is made -- so it is safe to remove this sentence.