### PR TITLE
Bump VDAF-07 to 08

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -353,7 +353,7 @@ else about the measurements. We call `F` the "aggregation function."
 
 This protocol is extensible and allows for the addition of new cryptographic
 schemes that implement the VDAF interface specified in
-{{!VDAF=I-D.draft-irtf-cfrg-vdaf-07}}. Candidates include:
+{{!VDAF=I-D.draft-irtf-cfrg-vdaf-08}}. Candidates include:
 
 * Prio3 ({{Section 7 of !VDAF}}), which allows for aggregate statistics such as
   sum, mean, histograms, etc.

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -991,7 +991,7 @@ follows:
 
 ~~~
 enc, payload = SealBase(pk,
-  "dap-07 input share" || 0x01 || server_role,
+  "dap-09 input share" || 0x01 || server_role,
   input_share_aad, plaintext_input_share)
 ~~~
 
@@ -1539,7 +1539,7 @@ attempts decryption of the payload with the following procedure:
 
 ~~~
 plaintext_input_share = OpenBase(encrypted_input_share.enc, sk,
-  "dap-07 input share" || 0x01 || server_role,
+  "dap-09 input share" || 0x01 || server_role,
   input_share_aad, encrypted_input_share.payload)
 ~~~
 
@@ -2152,7 +2152,7 @@ Encrypting an aggregate share `agg_share` for a given `AggregateShareReq` is
 done as follows:
 
 ~~~
-enc, payload = SealBase(pk, "dap-07 aggregate share" || server_role || 0x00,
+enc, payload = SealBase(pk, "dap-09 aggregate share" || server_role || 0x00,
   agg_share_aad, agg_share)
 ~~~
 
@@ -2182,7 +2182,7 @@ Specifically, given an encrypted input share, denoted `enc_share`, for a given
 batch selector, decryption works as follows:
 
 ~~~
-agg_share = OpenBase(enc_share.enc, sk, "dap-07 aggregate share" ||
+agg_share = OpenBase(enc_share.enc, sk, "dap-09 aggregate share" ||
   server_role || 0x00, agg_share_aad, enc_share.payload)
 ~~~
 


### PR DESCRIPTION
This is a breaking change, so bump the DAP version tag as well. (The next version tag is "dap-09".)