### PR TITLE
Prepare `draft-ietf-ppm-dap-10`

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1056,7 +1056,7 @@ follows:
 
 ~~~
 enc, payload = SealBase(pk,
-  "dap-09 input share" || 0x01 || server_role,
+  "dap-10 input share" || 0x01 || server_role,
   input_share_aad, plaintext_input_share)
 ~~~
 
@@ -1604,7 +1604,7 @@ attempts decryption of the payload with the following procedure:
 
 ~~~
 plaintext_input_share = OpenBase(encrypted_input_share.enc, sk,
-  "dap-09 input share" || 0x01 || server_role,
+  "dap-10 input share" || 0x01 || server_role,
   input_share_aad, encrypted_input_share.payload)
 ~~~
 
@@ -2206,7 +2206,7 @@ Encrypting an aggregate share `agg_share` for a given `AggregateShareReq` is
 done as follows:
 
 ~~~
-enc, payload = SealBase(pk, "dap-09 aggregate share" || server_role || 0x00,
+enc, payload = SealBase(pk, "dap-10 aggregate share" || server_role || 0x00,
   agg_share_aad, agg_share)
 ~~~
 
@@ -2236,7 +2236,7 @@ Specifically, given an encrypted input share, denoted `enc_share`, for a given
 batch selector, decryption works as follows:
 
 ~~~
-agg_share = OpenBase(enc_share.enc, sk, "dap-09 aggregate share" ||
+agg_share = OpenBase(enc_share.enc, sk, "dap-10 aggregate share" ||
   server_role || 0x00, agg_share_aad, enc_share.payload)
 ~~~
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -120,6 +120,21 @@ input is ever seen in the clear by any aggregator.
 
 (\*) Indicates a change that breaks wire compatibility with the previous draft.
 
+10:
+
+- Editorial changes from httpdir early review.
+
+- Poll collection jobs with HTTP GET instead of POST. (\*)
+
+- Upload reports with HTTP POST instead of PUT. (\*)
+
+- Clarify requirements for problem documents.
+
+- Provide guidance on batch sizes when running VDAFs with non-trivial
+  aggregation parameters.
+
+- Bump version tag from "dap-09" to "dap-10". (\*)
+
 09:
 
 - Fixed-size queries: make the maximum batch size optional.


### PR DESCRIPTION
There's no PPM session at IETF 119, but we nonetheless want to publish a new draft to keep DAP current.

Closes #551 