### PR TITLE
Clarify purpose of report ID uniqueness

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1694,12 +1694,14 @@ following checks:
    If this returns false, the input share MUST be marked as invalid with the
    error `report_replayed`.
 
-    * Implementation note: To detect replay attacks, each Aggregator is required
-      to keep track of the set of reports it has processed for a given task.
-      Because honest Clients choose the report ID at random, it is sufficient to
-      store the set of IDs of processed reports. However, implementations may
-      find it helpful to track additional information, like the timestamp, so
-      that the storage used for anti-replay can be sharded efficiently.
+    * Implementation note: To detect replay attacks in which an honest Client's
+      report is uploaded to the aggregators multiple times, each Aggregator is
+      required to keep track of the set of reports it has processed for a given
+      task. Because honest Clients choose the report ID at random, it is
+      sufficient to store the set of IDs of processed reports. However,
+      implementations may find it helpful to track additional information, like
+      the timestamp, so that the storage used for anti-replay can be sharded
+      efficiently.
 
 1. If the report pertains to a batch that was previously collected, then make
    sure the report was already included in all previous collections for the


### PR DESCRIPTION
Discuss explicitly the attack prevented by enforcing unique report IDs, which is to stop honest Client reports from being replayed. This would also be necessary to satisfy VDAF's requirement of nonce uniqueness, but it's not yet clear VDAF will impose that exact requirement (see [1]).

There's no functional change here, but hopefully being explicit can short-circuit future discussion of why we have this expensive requirement.

See #558 for motivating discussion.

[1]: https://github.com/cfrg/draft-irtf-cfrg-vdaf/pull/340