### PR TITLE
tls-presentation: Fix limits for length-prefixed fields

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -975,7 +975,7 @@ decreasing order of preference. This allows an Aggregator to support multiple
 HPKE configurations simultaneously.
 
 ~~~
-HpkeConfig HpkeConfigList<1..2^16-1>;
+HpkeConfig HpkeConfigList<10..2^16-1>;
 
 struct {
   HpkeConfigId id;
@@ -1093,7 +1093,7 @@ The Client then wraps each input share in the following structure:
 ~~~
 struct {
   Extension extensions<0..2^16-1>;
-  opaque payload<0..2^32-1>;
+  opaque payload<1..2^32-1>;
 } PlaintextInputShare;
 ~~~
 
@@ -1370,7 +1370,7 @@ struct {
 
 struct {
   ReportShare report_share;
-  opaque payload<0..2^32-1>;
+  opaque payload<5..2^32-1>;
 } PrepareInit;
 ~~~
 
@@ -1405,7 +1405,7 @@ struct {
 struct {
   opaque agg_param<0..2^32-1>;
   PartialBatchSelector part_batch_selector;
-  PrepareInit prepare_inits<1..2^32-1>;
+  PrepareInit prepare_inits<44..2^32-1>;
 } AggregationJobInitReq;
 ~~~
 
@@ -1528,7 +1528,7 @@ struct {
   ReportID report_id;
   PrepareRespState prepare_resp_state;
   select (PrepareResp.prepare_resp_state) {
-    case continue: opaque payload<0..2^32-1>;
+    case continue: opaque payload<5..2^32-1>;
     case finished: Empty;
     case reject:   PrepareError prepare_error;
   };
@@ -1592,7 +1592,7 @@ Otherwise the Helper responds with
 variant {
   ReportID report_id;
   PrepareRespState prepare_resp_state = continue;
-  opaque payload<0..2^32-1> = outbound;
+  opaque payload<5..2^32-1> = outbound;
 } PrepareResp;
 ~~~
 
@@ -1601,7 +1601,7 @@ message is structured as follows:
 
 ~~~
 struct {
-  PrepareResp prepare_resps<1..2^32-1>;
+  PrepareResp prepare_resps<26..2^32-1>;
 } AggregationJobResp;
 ~~~
 
@@ -1738,7 +1738,7 @@ report the Leader constructs a preparation continuation message:
 ~~~
 struct {
   ReportID report_id;
-  opaque payload<0..2^32-1>;
+  opaque payload<5..2^32-1>;
 } PrepareContinue;
 ~~~
 
@@ -1752,7 +1752,7 @@ initialization (see {{leader-init}}) with media type
 ~~~
 struct {
   uint16 step;
-  PrepareContinue prepare_continues<1..2^32-1>;
+  PrepareContinue prepare_continues<25..2^32-1>;
 } AggregationJobContinueReq;
 ~~~
 
@@ -1866,7 +1866,7 @@ Otherwise, if `outbound != None`, then the Helper's response is
 variant {
   ReportID report_id;
   PrepareRespState prepare_resp_state = continue;
-  opaque payload<0..2^32-1> = outbound;
+  opaque payload<5..2^32-1> = outbound;
 } PrepareResp;
 ~~~
 


### PR DESCRIPTION
Closes #110.

Assume 10 bytes for the smallest VDAF ping pong message: https://github.com/cfrg/draft-irtf-cfrg-vdaf/pull/428


* HpkeConfigList: The smallest HpkeConfig is 10 bytes: one byte for the
  config ID, two bytes for each algorithm ID, 2 bytes for the public key
  length prefix, and assume one byte for the public key (the actual
  value depends on which HPKE KEM algorithms are supported).

* PlaintextInputShare.payload: Assume 1 byte as the smallest input share
  (the actual value depends on which VDAFs are supported).

* PrepareInit.payload: 5 bytes lest ping pong message (see above)

* AggregationJobInitReq.prepare_inits: The smallest PrepareInit is 45
  bytes:

   * PrepareInit.report_share: 16 bytes for the report ID, 8 bytes for
     the timestamp, 0 bytes for the public share (this is empty for some
     Prio3 variants), 2 bytes for the public share length prefix, and
     for the HPKE ciphertext:

      * 1 for the config ID

      * assume 1 byte for the encapsulated key (depends on the supported
        KEMs) and 2 bytes for the length prefix

      * assume 1 byte for the ciphertext (depends on the supported
        AEADs) and 4 bytes for the length prefix

   * PrepareInit.payload: 5 bytes (smallest ping pong message) and 4
     bytes for the length prefix

* PrepareResp.payload: 5 bytes (smallest ping poing message)

* AggregationJobJesp.prepare_resps: The smallest PrepareResp has 26 bytes:

    * 16 bytes for the report ID, 1 byte for the variant discriminator,
      and 5 + 4 bytes length prefix for the ping pong message.

* PrepareContinue.payload: 5 bytes (smallest ping pong message)

* AggregationJobContinueReq.prepare_continues: The smallest
  PRepareContinue is 16 bytes for the report ID, and 5 + 4 bytes for
  the payload.

