### PR TITLE
Add synchronization concerns to operational considerations.

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1394,6 +1394,14 @@ and Helper then run the aggregate initialization flow to accomplish two tasks:
 
 The Leader and Helper initialization behavior is detailed below.
 
+Implementation note: the Leader will generally want to associate each report
+with a single aggregation job, as otherwise the duplicated reports will
+eventually be discarded as a replay. However, it is likely not appropriate to
+directly use the used-ID storage used for replay protection to determine which
+reports can be added to an aggregation job: certain errors (e.g.
+`report_too_early`) allow the report to be added to another aggregation job in
+the future; but storage into the used-ID storage is permanent.
+
 #### Leader Initialization {#leader-init}
 
 The Leader begins the aggregate initialization by sampling a fresh
@@ -1833,7 +1841,8 @@ following checks:
       determined by query ({{batch-mode}}) conveyed in these messages. Queries
       must satisfy the criteria covered in {{batch-validation}}. These criteria
       are meant to restrict queries in a way that makes it easy to determine
-      whether a report pertains to a batch that was collected.
+      whether a report pertains to a batch that was collected. See
+      {{distributed-systems}} for more information.
 
 1. Finally, if an Aggregator cannot determine if an input share is valid, it
    MUST mark the input share as invalid with error `report_dropped`. For
@@ -2662,6 +2671,65 @@ current time has not passed this task's `task_expiration`. Aggregator MAY delete
 the task and all data pertaining to this task after `task_expiration`.
 Implementors SHOULD provide for some leeway so the Collector can collect the
 batch after some delay.
+
+### Distributed-systems and Synchronization Concerns {#distributed-systems}
+
+Various parts of a DAP implementation will need to synchronize in order to
+ensure correctness during concurrent operation. This section describes the
+relevant concerns and makes suggestions as to potential implementation
+tradeoffs.
+
+* The upload interaction requires the Leader to ignore uploaded reports with a
+  duplicated ID, including concurrently-uploaded reports. This might be
+  implemented by synchronization or via an eventually-consistent process. If the
+  Leader wishes to alert the Client with a `reportRejected` error,
+  synchronization will be necessary to ensure all but one concurrent request
+  receive the error.
+
+* The Leader is responsible for generating aggregation jobs, and will generally
+  want to place each report in exactly one aggregation job. (The only event in
+  which a Leader will want to place a report in multiple aggregation jobs is if
+  the Helper rejects the report with `report_too_early`, in which case the
+  Leader can place the report into a later aggregation job.) This may require
+  synchronization between different components of the system which are
+  generating aggregation jobs. Note that placing a report into more than one
+  aggregation job will result in a loss of throughput, rather than a loss of
+  correctness, privacy, or robustness, so it is acceptable for implementations
+  to use an eventually-consistent scheme which may rarely place a report into
+  multiple aggregation jobs.
+
+* Aggregation is implemented as a sequence of aggregation steps by both the
+  Leader and the Helper. The Leader must ensure that each aggregation job is
+  only processed once concurrently, which may require synchronization between
+  the components responsible for performing aggregation. The Helper must ensure
+  that concurrent requests against the same aggregation job are handled
+  appropriately, which requires synchronization between the components handling
+  aggregation requests.
+
+* Aggregation requires checking and updating used-report storage as part of
+  implementing replay protection. This must be done while processing the
+  aggregation job, though which steps the checks are performed at is up to the
+  implementation. The checks and storage require synchronization, so that if two
+  aggregation jobs contianing the same report are processed, at most one
+  instance of the report will be aggregated. However, the interaction with the
+  used-report storage does not necessarily have to be synchronized with the
+  processing and storage for the remainder of the aggregation process. For
+  example, used-report storage could be implemented in a separate datastore than
+  is used for the remainder of data storage, without any transactionality
+  between updates to the two datastores.
+
+* The aggregation and collection interactions require synchronization to avoid
+  modifying the aggregate of a batch after it has already been collected. Any
+  reports being aggregated which pertain to a batch which has already been
+  collected must fail with a `batch_collected` error; correctly determining this
+  requires synchronizing aggregation with the completion of collection jobs (for
+  the Leader) or aggregate share requests (for the Helper). Also, the Leader
+  must complete all outstanding aggregation jobs for a batch before requesting
+  aggregate shares from the Helper, again requiring synchronization between the
+  Leader's collection and aggregation interactions. Further, the Helper must
+  determine the aggregated report count and checksum of aggregated report IDs
+  before responding to an aggregate share request, requiring synchronization
+  between the Helper's collection and aggregation interactions.
 
 # Compliance Requirements {#compliance}
 


### PR DESCRIPTION
Closes #556.

This is intended to list the parts of a DAP deployment where synchronization is required between different componenets of the system. This will hopefully be useful both as hints to implementers, as well as providing a guide to where we might hope to introduce the opportunity for eventual consistency.