### PR TITLE
Remove replay check from "input share validation" section.

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1819,18 +1819,6 @@ following checks:
    the same. If so, the Aggregator MUST mark the input share as invalid with
    error `invalid_message`.
 
-1. Check if the report has been previously aggregated. If so, the input share
-   MUST be marked as invalid with the error `report_replayed`. A report is
-   considered aggregated if its contribution would be included in a relevant
-   collection job.
-
-    * Implementation note: To detect replay attacks, each Aggregator is required
-      to keep track of the set of reports it has processed for a given task.
-      Because honest Clients choose the report ID at random, it is sufficient to
-      store the set of IDs of processed reports. However, implementations may
-      find it helpful to track additional information, like the timestamp, so
-      that the storage used for anti-replay can be sharded efficiently.
-
 1. If the report pertains to a batch that was previously collected, then the
    input share MUST be marked as invalid with error `batch_collected`.
 


### PR DESCRIPTION
The related implementation note is removed, too -- it is nowadays duplicative of the text in the Replay Protection section.

I think this was an intended part of #582, based on the commit text of that PR.