### PR TITLE
Update PrepareError allocations (*)

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1610,13 +1610,13 @@ enum {
 } PrepareRespState;
 
 enum {
-  batch_collected(0),
-  report_replayed(1),
-  report_dropped(2),
-  hpke_unknown_config_id(3),
-  hpke_decrypt_error(4),
-  vdaf_prep_error(5),
-  TODO_remove_me(6), /* TODO: replace/remove before RFC. */
+  reserved(0),
+  batch_collected(1),
+  report_replayed(2),
+  report_dropped(3),
+  hpke_unknown_config_id(4),
+  hpke_decrypt_error(5),
+  vdaf_prep_error(6),
   task_expired(7),
   invalid_message(8),
   report_too_early(9),


### PR DESCRIPTION
Wherever we have extension points in the protocol, we should reserve a `0` for testing purposes. We've done this for upload extensions and batch modes, but failed to do so for prepare errors. This is relevant because future DAP extensions might need to register prepare errors.

Reserve `0` and shift all remaining codepoints by `1`, except for those following `6`, which was allocated in a previous draft but earmarked for deletion in a future draft.