### PR TITLE
Rephrase the introduction of batch modes

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -889,7 +889,9 @@ Each measurement task has a preconfigured "batch mode". The batch mode defines
 both how reports may be partitioned into batches, as well as how these batches
 are addressed and the semantics of the query used for collection.
 
-This document defines the following batch modes:
+This document defines the time-interval and leader-selected batch modes.
+Batch modes are identified with a single byte in serialized messages, as
+follows:
 
 ~~~ tls-presentation
 enum {


### PR DESCRIPTION
Following PR #612, this sentence is unclear, because the batch modes are no longer listed in the following source code element. This PR instead lists them in the prose.