### PR TITLE
Small fixes to async aggregation/collection.

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1795,6 +1795,7 @@ message is structured as follows:
 enum {
   processing(0),
   ready(1),
+  (255)
 } AggregationJobStatus;
 
 struct {
@@ -2125,8 +2126,8 @@ The Helper constructs an `AggregationJobResp` message (see
 {{aggregation-helper-init}}) with each prep step. The order of the prep steps
 MUST match the Leader's `AggregationJobContinueReq`.
 
-The Helper responds to the Leader with HTTP status 200 OK, a body consisting
-of the `AggregationJobResp`, and the media type
+The Helper responds to the Leader with HTTP status 202 Accepted, a body
+consisting of the `AggregationJobResp`, and the media type
 "application/dap-aggregation-job-resp".
 
 Depending on the task parameters, processing an aggregation job may take some
@@ -2321,6 +2322,7 @@ structured as follows:
 enum {
   processing(0),
   ready(1),
+  (255)
 } CollectionJobStatus;
 
 struct {


### PR DESCRIPTION
Specifically:
 * Settle on 202 Accepted for the Helper's response code to aggregation continuation requests. Previously, the Leader Continuation section suggested 202 Accepted while the Helper Continuation section suggested 200 OK. Either code is fine by me, but we need to make the specification consistent.
 * Add maximum-value indicators to the aggregation & collection status messages. This is an editorial change: indicating the maximum value is optional per RFC 8446's presentation language, but doing so makes the specification clearer & is consistent with all other enumerated values defined in the specification.