### PR TITLE
Clarify language around public / private extension conflicts

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1894,9 +1894,9 @@ following checks:
    invalid with error `invalid_message`.
 
 1. Check if any two public or private report extensions have the same extension
-   type. (For the purposes of this check, a private report extension can
-   conflict with a public report extension.) If so, the Aggregator MUST mark the
-   input share as invalid with error `invalid_message`.
+   type. (For the purposes of this check, a public extension MUST NOT conflict
+   with a private extension.) If so, the Aggregator MUST mark the input share as
+   invalid with error `invalid_message`.
 
 1. If the report pertains to a batch that was previously collected, then the
    input share MUST be marked as invalid with error `batch_collected`.


### PR DESCRIPTION
Previous language could be interpreted to mean that public and private extensions are allowed to conflict.