### PR TITLE
move and reorg presentation language exceptions

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -711,17 +711,25 @@ report IDs.
 Communications between DAP participants are carried over HTTP {{!RFC9110}}. Use
 of HTTPS is REQUIRED to provide server authentication and confidentiality.
 
-## Representation Language
+## Presentation Language
 
 With some exceptions, we use the presentation language defined in {{!RFC8446,
 Section 3}} to define messages in the DAP protocol. Encoding and decoding of
 these messages as byte strings also follows {{RFC8446}}. We enumerate the
 exceptions below.
 
+### Variable-Length Vectors
+
+{{Section 3.4 of !RFC8446}} describes a syntax for variable-length vectors where
+a range of permitted lengths is provided. By convention, DAP always specifies
+the lower length limit of variable-length vectors to be `0`.
+
+### Structure Variants
+
 {{Section 3.7 of !RFC8446}} defines a syntax for structure fields whose values
 are constants. In this document, we do not use that notation, but use something
-similar to describe specific variants of structures containing enumerated types,
-described in {{!RFC8446, Section 3.8}}.
+similar to describe specific variants of structures that use an enumerated type
+as a discriminator, described in {{!RFC8446, Section 3.8}}.
 
 For example, suppose we have an enumeration and a structure defined as follows:
 
@@ -751,7 +759,7 @@ variant {
   uint32 always_present;
   ExampleEnum type = number;
   /* Only fields included in the `type == number`
-     variant is described */
+     variant are described */
   uint32 a_number;
 } ExampleStruct;
 ~~~
@@ -761,8 +769,9 @@ handle the `always_present` and `a_number` fields, but not the `type` field.
 This does not mean that the `type` field of `ExampleStruct` can only ever have
 value `number`; it means only that it has this type in this instance.
 
-This notation can also be used in structures where the enum field does not
-affect what fields are or are not present in the structure. For example:
+This notation can also be used in structures where the enum field is not used as
+a discriminant. For example, given the following structure containing an
+enumerator:
 
 ~~~ tls-presentation
 enum {
@@ -785,9 +794,6 @@ variant {
   opaque another_field<0..256>;
 } FailedOperation;
 ~~~
-
-Finally, by convention we do not specify the lower length limit of
-variable-length vectors. Rather, the lower limit is always set to `0`.
 
 ## HTTPS Request Authentication {#request-authentication}
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -524,84 +524,6 @@ Report share:
 
 {:br}
 
-## Representation Language
-
-With some exceptions, we use the presentation language defined in {{!RFC8446,
-Section 3}} to define messages in the DAP protocol. Encoding and decoding of
-these messages as byte strings also follows {{RFC8446}}. We enumerate the
-exceptions below.
-
-{{Section 3.7 of !RFC8446}} defines a syntax for structure fields whose values
-are constants. In this document, we do not use that notation, but use something
-similar to describe specific variants of structures containing enumerated types,
-described in {{!RFC8446, Section 3.8}}.
-
-For example, suppose we have an enumeration and a structure defined as follows:
-
-~~~ tls-presentation
-enum {
-  number(0),
-  string(1),
-  (255)
-} ExampleEnum;
-
-struct {
-  uint32 always_present;
-  ExampleEnum type;
-  select (ExampleStruct.type) {
-    case number: uint32 a_number;
-    case string: opaque a_string<0..10>;
-  };
-} ExampleStruct;
-~~~
-
-Then we describe the specific variant of `ExampleStruct` where `type == number`
-with a `variant` block as follows:
-
-~~~ tls-presentation
-variant {
-  /* Field exists regardless of variant */
-  uint32 always_present;
-  ExampleEnum type = number;
-  /* Only fields included in the `type == number`
-     variant is described */
-  uint32 a_number;
-} ExampleStruct;
-~~~
-
-The protocol text accompanying this would explain how implementations should
-handle the `always_present` and `a_number` fields, but not the `type` field.
-This does not mean that the `type` field of `ExampleStruct` can only ever have
-value `number`; it means only that it has this type in this instance.
-
-This notation can also be used in structures where the enum field does not
-affect what fields are or are not present in the structure. For example:
-
-~~~ tls-presentation
-enum {
-  something(0),
-  something_else(1),
-  (255)
-} FailureReason;
-
-struct {
-  FailureReason failure_reason;
-  opaque another_field<0..256>;
-} FailedOperation;
-~~~
-
-The protocol text might include a description like:
-
-~~~ tls-presentation
-variant {
-  FailureReason failure_reason = something;
-  opaque another_field<0..256>;
-} FailedOperation;
-~~~
-
-Finally, by convention we do not specify the lower length limit of
-variable-length vectors. Rather, the lower limit is always set to `0`.
-
 # Overview {#overview}
 
 The protocol is executed by a large set of Clients and a pair of servers
@@ -788,6 +710,84 @@ report IDs.
 
 Communications between DAP participants are carried over HTTP {{!RFC9110}}. Use
 of HTTPS is REQUIRED to provide server authentication and confidentiality.
+
+## Representation Language
+
+With some exceptions, we use the presentation language defined in {{!RFC8446,
+Section 3}} to define messages in the DAP protocol. Encoding and decoding of
+these messages as byte strings also follows {{RFC8446}}. We enumerate the
+exceptions below.
+
+{{Section 3.7 of !RFC8446}} defines a syntax for structure fields whose values
+are constants. In this document, we do not use that notation, but use something
+similar to describe specific variants of structures containing enumerated types,
+described in {{!RFC8446, Section 3.8}}.
+
+For example, suppose we have an enumeration and a structure defined as follows:
+
+~~~ tls-presentation
+enum {
+  number(0),
+  string(1),
+  (255)
+} ExampleEnum;
+
+struct {
+  uint32 always_present;
+  ExampleEnum type;
+  select (ExampleStruct.type) {
+    case number: uint32 a_number;
+    case string: opaque a_string<0..10>;
+  };
+} ExampleStruct;
+~~~
+
+Then we describe the specific variant of `ExampleStruct` where `type == number`
+with a `variant` block as follows:
+
+~~~ tls-presentation
+variant {
+  /* Field exists regardless of variant */
+  uint32 always_present;
+  ExampleEnum type = number;
+  /* Only fields included in the `type == number`
+     variant is described */
+  uint32 a_number;
+} ExampleStruct;
+~~~
+
+The protocol text accompanying this would explain how implementations should
+handle the `always_present` and `a_number` fields, but not the `type` field.
+This does not mean that the `type` field of `ExampleStruct` can only ever have
+value `number`; it means only that it has this type in this instance.
+
+This notation can also be used in structures where the enum field does not
+affect what fields are or are not present in the structure. For example:
+
+~~~ tls-presentation
+enum {
+  something(0),
+  something_else(1),
+  (255)
+} FailureReason;
+
+struct {
+  FailureReason failure_reason;
+  opaque another_field<0..256>;
+} FailedOperation;
+~~~
+
+The protocol text might include a description like:
+
+~~~ tls-presentation
+variant {
+  FailureReason failure_reason = something;
+  opaque another_field<0..256>;
+} FailedOperation;
+~~~
+
+Finally, by convention we do not specify the lower length limit of
+variable-length vectors. Rather, the lower limit is always set to `0`.
 
 ## HTTPS Request Authentication {#request-authentication}
 


### PR DESCRIPTION
Restructures the exceptions to RFC 8446 presentation language into individual, titled sections to make it more obvious for readers how many deviations there are. Also moves that entire section to section 3 Message Transport. This is because (1) we're discussing encoding messages on the wire so Message Transport is the appropriate place and (2) we should minimize the text before we get to the Overview section so that readers new to DAP get there as soon as possible.

Stacked on #653