### PR TITLE
Illustrate object lifecycles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@
 archive.json
 draft-ietf-ppm-dap.xml
 lib
+/node_modules/
+package-lock.json
 report.xml
 venv/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "aasvg": "^0.4.2"
+  }
+}


### PR DESCRIPTION
Adds a section to the overview that includes a diagram illustrating the lifecycle of objects, i.e. how reports become aggregation jobs become aggregate shares etc. Also adds a prose section explaining the arity of each object.

Resolves #560 