### PR TITLE
Editorial Nits

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1707,7 +1707,7 @@ whether the corresponding report ID is in the set of stored IDs.
 
 The Leader begins an aggregation job by choosing a set of candidate reports that
 pertain to the same DAP task and a job ID which MUST be unique within the scope
-of the task. The job ID is a 16-byte value, structured as follows:
+of the DAP task. The job ID is a 16-byte value, structured as follows:
 
 ~~~ tls-presentation
 opaque AggregationJobID[16];

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1868,7 +1868,7 @@ The `AggregationJobResp.prepare_resps` field must include exactly the same
 report IDs in the same order as the Leader's `AggregationJobInitReq`. Otherwise,
 the Leader MUST abort the aggregation job.
 
-Otherwise, the Leader proceeds as follows with each report:
+Continuing, the Leader proceeds as follows with each report:
 
 1. If the inbound prep response has type "continue", then the Leader computes
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1834,8 +1834,8 @@ This message consists of:
   specifies a "batch ID" that determines the batch to which each report for
   this aggregation job belongs ({{leader-selected-batch-mode}}).
 
-  Documents that define batch modes MUST specify the content this field; see
-  {{extending-this-doc}} for details.
+  Documents that define batch modes MUST specify the content of this field;
+  see {{extending-this-doc}} for details.
 
   The indicated batch mode MUST match the task's batch mode. Otherwise, the
   Helper MUST abort with error `invalidMessage`.

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2463,7 +2463,7 @@ update the batch buckets:
 * Update the aggregate share `agg_share` to `Vdaf.agg_update(agg_param,
   agg_share, out_share)`.
 * Increment the count by 1.
-* Update the checksum value to the bitwise-XOR of the checksum value with the
+* Update the checksum value to the bitwise XOR of the checksum value with the
   SHA256 {{!SHS=DOI.10.6028/NIST.FIPS.180-4}} hash of the report ID associated
   with the output share.
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -3016,7 +3016,8 @@ batch buckets identifiers for the batch interval is
 `(batch_interval.start,
   batch_interval.start + time_precision)`,
 `(batch_interval.start + time_precision,
-  batch_interval.start + 2*time_precision)`, ...,
+  batch_interval.start + 2*time_precision)`,
+  ...,
 `(batch_interval.start + batch_interval.duration - time_precision) +
   batch_interval.start + batch_interval.duration)`.
 


### PR DESCRIPTION
Honestly the draft, as big as it is, is pretty clean. Here are a series of commits that fix little nits I have, like using `Otherwise` twice in a row, or differences in hyphenation. 