### PR TITLE
Other problem types may be any URI

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1035,7 +1035,7 @@ standard tokens for use in the "type" field:
 These types are scoped to the errors sub-namespace of the DAP URN namespace,
 e.g., urn:ietf:params:ppm:dap:error:invalidMessage.
 
-This list is not exhaustive. The server MAY return errors set to a URN other
+This list is not exhaustive. The server MAY return errors set to a URI other
 than those defined above. Servers MUST NOT use the DAP URN namespace for errors
 not listed in the appropriate IANA registry (see {{urn-space}}). The "detail"
 member of the Problem Details document includes additional diagnostic


### PR DESCRIPTION
This is a follow-up to #661. While the problem types defined in this document are all URNs, we should still allow for servers to use other URIs that are not URNs as problem types. In particular, our implementation, Janus, uses `about:blank` in one case, where want to add a detail field while keeping the semantics of one of the HTTP status codes. We also use `https:` URLs for a couple of implementation-specific error cases.