### PR TITLE
Fold batch validation into collection job, aggregate share sections

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2138,10 +2138,10 @@ for each input share in the job:
       has completed a collection job for a CollectionJobReq message from the
       Collector; the Helper considers a batch to be collected once it has
       responded to an `AggregateShareReq` message from the Leader. A batch is
-      determined by query ({{batch-modes}}) conveyed in these messages. Queries
-      must satisfy the criteria covered in {{batch-validation}}. These criteria
-      are meant to restrict queries in a way that makes it easy to determine
-      whether a report pertains to a batch that was collected. See
+      determined by query conveyed in these messages. Queries must satisfy the
+      criteria defined by their batch mode ({{batch-modes}}). These criteria are
+      meant to restrict queries in a way that makes it easy to determine whether
+      a report pertains to a batch that was collected. See
       {{distributed-systems}} for more information.
 
 1. If an Aggregator cannot determine if an input share is valid, it MUST mark
@@ -3206,29 +3206,6 @@ agg_share = OpenBase(
 The `OpenBase()` function is as specified in {{!HPKE, Section 6.1}} for the
 ciphersuite indicated by the HPKE configuration.
 
-### Batch Validation {#batch-validation}
-
-When the Leader receives a `Query` in the request from the Collector during
-collection initialization ({{collect-init}}), it must first check that the
-batch determined by the query can be collected. The Helper performs the same
-check when it receives a `BatchSelector` in the request from the Leader for its
-aggregate share ({{collect-aggregate}}).
-
-First, the Aggregator checks if the request (the `CollectionJobReq` for the
-Leader and the `AggregateShareReq` for the Helper) identifies a valid set of
-batch buckets ({{batch-buckets}}). If not, it MUST abort the request with
-`batchInvalid`.
-
-Next, the Aggregator checks that the number of reports in the batch is equal to
-or greater than the task's minimum batch size. If not, then the Helper MUST
-abort with error `invalidBatchSize`. The Leader SHOULD wait for more reports to
-be validated and try the collection job again later.
-
-Next, the Aggregator checks if any of the batch buckets identified by the
-request have already been collected. If so, it MUST abort with "batchOverlap".
-
-Finally, the batch mode may define additional batch validation rules.
-
 # Batch Modes {#batch-modes}
 
 This section defines an initial set of batch modes for DAP. New batch modes may
@@ -3547,7 +3524,7 @@ not necessary to store the complete reports. Each Aggregator only needs to
 store an aggregate share for each possible batch bucket i.e., the batch
 interval for time-interval or batch ID for leader-selected, along with a flag
 indicating whether the aggregate share has been collected. This is due to the
-requirement for queries to respect bucket boundaries. See {{batch-validation}}.
+requirement for queries to respect bucket boundaries. See {{batch-modes}}.
 
 However, Aggregators are also required to implement several per-report checks
 that require retaining a number of data artifacts. For example, to detect replay

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2962,8 +2962,18 @@ the job with error `unrecognizedTask`.
 The indicated batch mode MUST match the task's batch mode. If not, the Helper
 MUST fail the job with `invalidMessage`.
 
-The Helper then verifies that the request meets the requirements in
-{{batch-validation}}. If not, it MUST fail the job with the indicated error.
+The Helper then verifies that the `BatchSelector` in the Leader's request
+determines a batch that can be collected. If the selector does not identify a
+valid set of batch buckets according to the criteria defined by the batch mode
+in use ({{batch-modes}}), then the Helper MUST fail the job with error
+`batchInvalid`.
+
+If any of the batch buckets identified by the selector have already been
+collected, then the Helper MUST fail the job with error `batchOverlap`.
+
+If the number of validated reports in the batch is not equal to or greater than
+the task's minimum batch size, then the Helper MUST abort with
+`invalidBatchSize`.
 
 The aggregation parameter MUST match the aggregation parameter used in
 aggregation jobs pertaining to this batch. If not, the Helper MUST fail the job


### PR DESCRIPTION
Issue #662 highlights ambiguities in the specification of Leader handling of collection jobs or Helper handling of aggregate shares. In my opinion, this ambiguity was caused in part by trying to write a single batch validation section fro both, which forces readers to flip back and forth between sections and carefully parse nuanced protocol text to figure out exactly what requirements apply to either role. This PR addresses that problem by removing the {{batch-validation}} section and "inlining" its contents into the respective Leader and Helper sections. We also clarify who is responsible for retrying collection jobs.

See individual commits for more discussion.

Resolves #662 