### PR TITLE
HTTP resource deletion vs. replay protection

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2701,7 +2701,8 @@ encoded(struct { prepare_resps } AggregationJobResp)
 
 If for whatever reason, the Leader must abandon an aggregation job, it SHOULD
 let the Helper know it can clean up its state by sending a DELETE request to the
-job.
+job. Deletion of an aggregation job MUST NOT delete information needed for
+replay or double collection checks ({{replay-protection}}).
 
 #### Example
 
@@ -2989,8 +2990,11 @@ encoded(struct {
 ### Collection Job Deletion
 
 The Collector can send a DELETE request to the collection job, which indicates
-to the Leader that it can abandon the collection job and discard all state
-related to it.
+to the Leader that it can abandon the collection job and discard state related
+to it.
+
+Aggregators MUST NOT delete information needed for replay or double collection
+checks ({{replay-protection}}).
 
 Collectors MUST authenticate their requests to Leaders using a scheme that meets
 the requirements in {{request-authentication}}.
@@ -3238,8 +3242,11 @@ encoded(struct {
 ### Aggregate Share Deletion
 
 The Leader can send a DELETE request to the aggregate share, which indicates to
-the Helper that it can abandon the aggregate share and discard all state related
-to it.
+the Helper that it can abandon the aggregate share and discard state related to
+it.
+
+Aggregators MUST NOT delete information needed for replay or double collection
+checks ({{replay-protection}}).
 
 Leaders MUST authenticate their requests to Helpers using a scheme that meets
 the requirements in {{request-authentication}}.


### PR DESCRIPTION
Clarify that DELETEing aggregation jobs, aggregate shares or collection jobs MUST NOT delete any information needed by aggregators for {{replay-protection}}.

Resolves #700