### PR TITLE
Clean up recovery and async handling language

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1238,8 +1238,6 @@ to the HTTP client's request until the resource is ready, in which case it
 responds with the resource's representation, or handling the request fails, in
 which case it MUST abort with the error that caused the failure.
 
-HTTP clients MUST support either asynchronous or synchronous request handling.
-
 ## Aggregation Parameter Validation {#agg-param-validation}
 
 For each batch it collects, the Collector chooses an aggregation parameter used


### PR DESCRIPTION
I opted to address #694 and #695 together because I figured they'd touch some of the same text and thus that this would be the best way to avoid messy merges.

See individual commit messages for details as well as comments I left inline. But the highlights:

- Hoist discussion of request authentication requirements into {{request-authentication}}
-  Describe generic semantics for asynchronous request handling in{{http-resources}} and then refer to that from specification of aggregation job init, aggregation job continue, aggregate share and collection job handling
- Make it clear that DAP's usage of GET/POST/PUT conforms to RFC 9110 safety and idempotence
- Remove mention of Leader being allowed to send agg job init multiple times; this is implied by the method being PUT
- Make it clear that mutating an aggregation job init or an aggregation job continue step are both illegal

Resolves #694
Resolves #695