### PR TITLE
Use HTTP message content length where possible

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1392,7 +1392,7 @@ struct {
 } UploadRequest;
 ~~~
 
-Here `message_length` denotes the length of the HTTP message content ({{!RFC9110,
+Here `message_length` is the length of the HTTP message content ({{!RFC9110,
 Section 6.4}}).
 
 Each upload request contains a sequence of `Report` with the following fields:
@@ -1960,7 +1960,7 @@ struct {
 struct {
   opaque agg_param<0..2^32-1>;
   PartialBatchSelector part_batch_selector;
-  PrepareInit prepare_inits<44..2^32-1>;
+  PrepareInit prepare_inits[prepare_inits_length];
 } AggregationJobInitReq;
 ~~~
 
@@ -1977,7 +1977,10 @@ This message consists of:
   {{batch-modes}}.
 
 * `prepare_inits`: the sequence of `PrepareInit` messages constructed in the
-  previous step.
+  previous step. Here `prepare_inits_length` is the length of the HTTP message
+  content ({{!RFC9110, Section 6.4}}), minus the lengths in octets of
+  `agg_param` and `part_batch_selector.` That is, the remainder of the HTTP
+  message consists of `prepare_inits`.
 
 The Leader sends the `AggregationJobInitReq` in the body of a PUT request to the
 aggregation job with a media type of "application/dap-aggregation-job-init-req".
@@ -2163,12 +2166,15 @@ which is structured as follows:
 
 ~~~ tls-presentation
 struct {
-  PrepareResp prepare_resps<17..2^32-1>;
+  PrepareResp prepare_resps[message_length];
 } AggregationJobResp;
 ~~~
 
-where `prepare_resps` are the outbound `PrepareResp` messages for each report
-computed in the previous step. The order MUST match
+Here `message_length` is the length of the HTTP message content ({{!RFC9110,
+Section 6.4}}).
+
+`prepare_resps` is the outbound `PrepareResp` messages for each report computed
+in the previous step. The order MUST match
 `AggregationJobInitReq.prepare_inits`. The media type for `AggregationJobResp`
 is "application/dap-aggregation-job-resp".
 
@@ -2259,6 +2265,7 @@ The Helper handles the aggregation job initialization synchronously:
 PUT /helper/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/aggregation_jobs/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-aggregation-job-init-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -2274,6 +2281,7 @@ encoded(struct {
 
 HTTP/1.1 200
 Content-Type: application/dap-aggregation-job-resp
+Content-Length: 100
 
 encoded(struct { prepare_resps } AggregationJobResp)
 ~~~
@@ -2284,6 +2292,7 @@ Or asynchronously:
 PUT /helper/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/aggregation_jobs/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-aggregation-job-init-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -2313,6 +2322,7 @@ Authorization: Bearer auth-token
 
 HTTP/1.1 200
 Content-Type: application/dap-aggregation-job-resp
+Content-Length: 100
 
 encoded(struct { prepare_resps } AggregationJobResp)
 ~~~
@@ -2373,13 +2383,15 @@ Next, the Leader sends a POST to the aggregation job with media type
 ~~~ tls-presentation
 struct {
   uint16 step;
-  PrepareContinue prepare_continues<21..2^32-1>;
+  PrepareContinue prepare_continues[prepare_continues_length];
 } AggregationJobContinueReq;
 ~~~
 
 The `step` field is the step of DAP aggregation that the Leader just reached and
 wants the Helper to advance to. The `prepare_continues` field is the sequence of
-preparation continuation messages constructed in the previous step. The
+preparation continuation messages constructed in the previous step. Here
+`prepare_continues_length` is the length of the HTTP message content
+({{!RFC9110, Section 6.4}}), minus the length in octets of `step`. The
 `PrepareContinue` elements MUST be in the same order as the previous request to
 the aggregation job, omitting any reports that were previously rejected by
 either Aggregator.
@@ -2650,6 +2662,7 @@ The Helper handles the aggregation job continuation synchronously:
 POST /helper/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/aggregation_jobs/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-aggregation-job-continue-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -2659,6 +2672,7 @@ encoded(struct {
 
 HTTP/1.1 200
 Content-Type: application/dap-aggregation-job-resp
+Content-Length: 100
 
 encoded(struct { prepare_resps } AggregationJobResp)
 ~~~
@@ -2669,6 +2683,7 @@ Or asynchronously:
 POST /helper/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/aggregation_jobs/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-aggregation-job-continue-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -2694,6 +2709,7 @@ Authorization: Bearer auth-token
 
 HTTP/1.1 200
 Content-Type: application/dap-aggregation-job-resp
+Content-Length: 100
 
 encoded(struct { prepare_resps } AggregationJobResp)
 ~~~
@@ -2757,7 +2773,7 @@ struct {
 
 struct {
   Query query;
-  opaque agg_param<0..2^32-1>; /* VDAF aggregation parameter */
+  opaque agg_param[agg_param_length];
 } CollectionJobReq;
 ~~~
 
@@ -2765,7 +2781,10 @@ struct {
   indicated batch mode ({{batch-modes}}).
 
 * `agg_param`, an aggregation parameter for the VDAF being executed. This is
-  the same value as in `AggregationJobInitReq` (see {{leader-init}}).
+  the same value as in `AggregationJobInitReq` (see {{leader-init}}). Here
+  `agg_param_length` is the length of the HTTP message content ({{!RFC9110,
+  Section 6.4}}) minus the length in octets of query. That is, `agg_param`
+  consists of the remainder of the HTTP message.
 
 Depending on the VDAF scheme and how the Leader is configured, the Leader and
 Helper may already have prepared a sufficient number of reports satisfying the
@@ -2887,6 +2906,7 @@ The Leader handles the collection job request synchronously:
 PUT /leader/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/collection_jobs/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-collection-job-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -2923,6 +2943,7 @@ Or asynchronously:
 PUT /leader/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/collection_jobs/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-collection-job-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -3041,9 +3062,9 @@ struct {
 
 struct {
   BatchSelector batch_selector;
-  opaque agg_param<0..2^32-1>;
   uint64 report_count;
   opaque checksum[32];
+  opaque agg_param[agg_param_length];
 } AggregateShareReq;
 ~~~
 
@@ -3054,6 +3075,10 @@ The structure contains the following parameters:
   indicated batch mode (see {{batch-modes}}.
 
 * `agg_param`: The encoded aggregation parameter for the VDAF being executed.
+  Here `agg_param_length` is the length of the HTTP message content ({{!RFC9110,
+  Section 6.4}}) minus the lengths in octets of `batch_selector`, `report_count`
+  and `checksum`. That is `agg_param` consists of the remainder of the HTTP
+  message.
 
 * `report_count`: The number number of reports included in the batch, as
   computed above.
@@ -3139,6 +3164,7 @@ The Helper handles the aggregate share request synchronously:
 PUT /helper/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/aggregate_shares/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-aggregate-share-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -3151,9 +3177,9 @@ encoded(struct {
       } Interval,
     } TimeIntervalBatchSelectorConfig),
   } BatchSelector,
-  agg_param = [0x00, 0x01, ...],
   report_count = 1000,
   checksum = [0x0a, 0x0b, ..., 0x0f],
+  agg_param = [0x00, 0x01, ...],
 } AggregateShareReq)
 
 HTTP/1.1 200
@@ -3170,6 +3196,7 @@ Or asynchronously:
 PUT /helper/tasks/8BY0RzZMzxvA46_8ymhzycOB9krN-QIGYvg_RsByGec/aggregate_shares/lc7aUeGpdSNosNlh-UZhKA
 Host: example.com
 Content-Type: application/dap-aggregate-share-req
+Content-Length: 100
 Authorization: Bearer auth-token
 
 encoded(struct {
@@ -3182,9 +3209,9 @@ encoded(struct {
       } Interval,
     } TimeIntervalBatchSelectorConfig),
   } BatchSelector,
-  agg_param = [0x00, 0x01, ...],
   report_count = 1000,
   checksum = [0x0a, 0x0b, ..., 0x0f],
+  agg_param = [0x00, 0x01, ...],
 } AggregateShareReq)
 
 HTTP/1.1 200


### PR DESCRIPTION
In #686, we use the length of the enclosing HTTP message to figure out how long protocol messages are. For consistency, we now do the same thing for:

- AggregationJobInitReq
- AggregationJobResp
- AggregationJobContinueReq
- CollectionJobReq
- AggregateShareReq

In the last case, the message fields had to be re-ordered so that `agg_param` comes last.

Additionally, the word "denotes" was misused in several places. For example, we had:

```
struct {
  Report reports[message_length];
} UploadRequest;

Here `message_length` denotes the length of the HTTP message content...
```

Per Merriam-Webster, to denote means "to serve as an indication of" ([1]). Implementations are not meant to use the length of `reports` as an indication of how long the HTTP message content is. It's the other way around. Let's just say "is" and avoid this trouble.

[1]: https://www.merriam-webster.com/dictionary/denote

Closes #714