### PR TITLE
Fix typo in HpkeConfigList cardinality presentation

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1312,7 +1312,7 @@ support multiple HPKE configurations and multiple sets of algorithms
 simultaneously.
 
 ~~~ tls-presentation
-HpkeConfig HpkeConfigList<10..2^16-1>;
+HpkeConfig HpkeConfigList<1..2^16-1>;
 
 struct {
   HpkeConfigId id;


### PR DESCRIPTION
Text says 'The `HpkeConfigList` contains one or more `HpkeConfig`s' but we went from `0` to `10`, when we meant to go to `1`.