### PR TITLE
Narrow DELETE statement to apply to completed aggregation jobs only

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2849,8 +2849,8 @@ replay and double collection checks ({{batch-buckets}}) and MAY be
 included in future aggregation jobs.
 
 If the Leader must abandon an aggregation job, it SHOULD let the Helper know it
-can clean up its state by sending a DELETE request to the job. Deletion of an
-aggregation job MUST NOT delete information needed for replay or double
+can clean up its state by sending a DELETE request to the job. Deletion of a
+completed aggregation job MUST NOT delete information needed for replay or double
 collection checks.
 
 #### Example


### PR DESCRIPTION
This statement about how deleting an aggregation job MUST NOT delete replay check information can be confusing or surprising, since it comes right after a paragraph saying that after a leader abandons an aggregation job and sends a DELETE request, its reports can be included in future aggregation jobs. I think the way that this apparent contradiction is resolved is that we only need to prevent the report from being aggregated into multiple batches, so we only need to warn against deleting replay information for already-completed aggregation jobs here.