### PR TITLE
Specify the Input Share Validation algorithm may run in any order

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -2397,7 +2397,7 @@ Otherwise, the Aggregator outputs the resulting PlaintextInputShare
 #### Input Share Validation {#input-share-validation}
 
 Before initialization, Aggregators MUST perform the following checks for each
-input share in the job:
+input share in the job, in any order:
 
 1. Check that the input share can be decoded as specified by the VDAF. If not,
    the input share MUST be marked as invalid with the error `invalid_message`.


### PR DESCRIPTION
Since the Input Share Validation algorithm is a numbered list, it implies an order of steps for compliant implementations. The first step of it, checking that input shares can be decoded, implies that compliant implementations need to check the public and private shares then, before proceeding.

This means we need to spend the time doing the HPKE Open step on the private data right away, even if a subsequent (inexpensive) timestamp check turns out to cause us to abort.

This change reorders the list to put the input share decoding step _after_ the inexpensive timestamp checks, just before the extension ones (which also depend on the plaintext).