### PR TITLE
Widen types used in VDAF config structs

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -4976,43 +4976,64 @@ used.
 
 ~~~ tls-presentation
 struct {
-    uint32 max_measurement; /* largest summand */
+    uint64 max_measurement;
 } Prio3SumConfig;
 ~~~
+
+`max_measurement` is the largest summand permitted in this instantiation of the
+VDAF. The value MUST be less than the modulus of the field associated with the
+circuit; see {{!VDAF, Section 6.1.4}}.
 
 ## Prio3SumVec
 
 ~~~ tls-presentation
 struct {
-    uint32 length;          /* length of the vector */
-    uint32 max_measurement; /* maximum value of each summand */
-    uint32 chunk_length;    /* size of each proof chunk */
+    uint32 length;
+    uint64 max_measurement;
+    uint32 chunk_length;
 } Prio3SumVecConfig;
 ~~~
+
+- `length` is the length of the vectors being summed.
+- `max_measurement` is the largest summand permitted in this instantiation of
+  the VDAF.
+- `chunk_length` is the size of each proof chunk.
 
 ## Prio3Histogram
 
 ~~~ tls-presentation
 struct {
-    uint32 length;       /* number of buckets */
-    uint32 chunk_length; /* size of each proof chunk */
+    uint32 length;
+    uint32 chunk_length;
 } Prio3HistogramConfig;
 ~~~
+
+- `length` is the number of buckets in the histogram.
+- `chunk_length` is the size of each proof chunk.
 
 ## Prio3MultihotCountVec
 
 ~~~ tls-presentation
 struct {
-    uint32 length;       /* length of the vector */
-    uint32 chunk_length; /* size of each proof chunk */
-    uint32 max_weight;   /* largest vector weight */
+    uint32 length;
+    uint32 chunk_length;
+    uint64 max_weight;
 } Prio3MultihotCountVecConfig;
 ~~~
+
+- `length` is the length of the vectors being summed.
+- `chunk_length` is the size of each proof chunk.
+- `max_weight` is the largest weight allowed for measurements; the maximum
+  number of true entries in the bit vector. The value MUST be less than the
+  modulus of the field associated with the circuit; see {{!VDAF, Section
+  6.1.4}}.
 
 ## Poplar1
 
 ~~~ tls-presentation
 struct {
-    uint16 bits; /* bit length of the input string */
+    uint16 bits;
 } Poplar1Config;
 ~~~
+
+`bits` is the number of bits in input strings.


### PR DESCRIPTION
The VDAF config structs inherited from draft-ietf-ppm-dap-taskprov used `uint32` everywhere. That's probably fine for things like the number of buckets in `Prio3Histogram`: the performance is unlikely to scale to vectors of 2^32-1 or more entries. However it's unfortunate to forbid particularly large measurements in `Prio3Sum` or `Prio3SumVec`. Those VDAFs use `Field64` and `Field128`, respectively, so they're capable of representing measurements exceeding `2^32-1` without a performance hit.

This commit widens all the VDAF config structure fields.

`Prio3Sum::max_measurement` is now `uint64`.
`Prio3SumVec::max_measurement` is now `uint128` (we add a simple definition of that type in {{basic-definitions}}`.

I widened all the remaining types (`length`s, `chunk_length`s, `max_weight`) to `uint64`. We _could_ leave these as `uint32` and it's unlikely it would restrict the utility of VDAFs. But on the other hand, these quantities describe lengths of vectors or slices, and since the majority of deployment targets are going to be LP64, using a 64 bit type for this seems more natural to me.

See also some discussion in the #ppm channel of ietf.slack.com ([1]).

[1]: https://ietf.slack.com/archives/C02P9620XT6/p1773341361058649