### PR TITLE
Audit `ReportError` variants and make sure they're used properly

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1343,7 +1343,6 @@ enum {
   invalid_message(8),
   report_too_early(9),
   task_not_started(10),
-  outdated_config(11),
   unknown_verification_key_id(12),
   (255)
 } ReportError;
@@ -1878,10 +1877,11 @@ and includes the `ReportId` from the input and a `ReportError`
 is always less than or equal to the length of the upload sequence.
 
 If the Leader does not recognize the `config_id` in the encrypted input share,
-it sets the corresponding error field to `outdated_config`. When the Client
-receives an `outdated_config` error, it SHOULD invalidate any cached
-`HpkeConfigList` and retry with a freshly generated `Report`. If this retried
-upload does not succeed, the Client SHOULD abort and discontinue retrying.
+it sets the corresponding error field to `hpke_unknown_config_id`. When the
+Client receives an `hpke_unknown_config_id` error, it SHOULD invalidate any
+cached `HpkeConfigList` and retry with a freshly generated `Report`. If this
+retried upload does not succeed, the Client SHOULD abort and discontinue
+retrying.
 
 If a report's ID matches that of a previously uploaded report, the Leader MUST
 discard it. In addition, it MAY set the corresponding error field to
@@ -2628,10 +2628,15 @@ plaintext_input_share = OpenBase(encrypted_input_share.enc, sk,
 The `OpenBase()` function is as specified in {{!HPKE, Section 6.1}} for the
 ciphersuite indicated by the HPKE configuration.
 
-If the HPKE configuration ID is unrecognized or decryption fails, the Aggregator
-marks the report share as invalid with the error `hpke_decrypt_error`.
-Otherwise, the Aggregator outputs the resulting PlaintextInputShare
-`plaintext_input_share`.
+If the HPKE configuration ID is unrecognized, the Aggregator marks the report
+share as invalid with the error `hpke_unknown_config_id`. If reports are
+rejected for this reason, Clients MAY retry the report upload after fetching
+current HPKE configurations for the Aggregators and re-encrypting the reports,
+though this may not be possible in all deployments.
+
+If decryption fails, the Aggregator marks the report share as invalid with the
+error `hpke_decrypt_error`. Otherwise, the Aggregator outputs the resulting
+PlaintextInputShare `plaintext_input_share`.
 
 #### Input Share Validation {#input-share-validation}
 
@@ -4903,7 +4908,6 @@ The initial contents of this registry are listed below in {{report-error-id}}.
 | `0x08` | `invalid_message`             | {{basic-definitions}} of RFX XXXX |
 | `0x09` | `report_too_early`            | {{basic-definitions}} of RFX XXXX |
 | `0x0A` | `task_not_started`            | {{basic-definitions}} of RFX XXXX |
-| `0x0B` | `outdated_config`             | {{basic-definitions}} of RFX XXXX |
 | `0x0C` | `unknown_verification_key_id` | {{basic-definitions}} of RFC XXXX |
 {: #report-error-id title="Initial contents of the DAP Report Error Identifiers
 registry."}

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1339,9 +1339,9 @@ enum {
   hpke_unknown_config_id(4),
   hpke_decrypt_error(5),
   vdaf_verify_error(6),
-  invalid_message(8),
-  report_too_early(9),
-  unknown_verification_key_id(12),
+  invalid_message(7),
+  report_too_early(8),
+  unknown_verification_key_id(9),
   (255)
 } ReportError;
 ~~~
@@ -4898,9 +4898,9 @@ The initial contents of this registry are listed below in {{report-error-id}}.
 | `0x04` | `hpke_unknown_config_id`      | {{basic-definitions}} of RFX XXXX |
 | `0x05` | `hpke_decrypt_error`          | {{basic-definitions}} of RFX XXXX |
 | `0x06` | `vdaf_verify_error`           | {{basic-definitions}} of RFX XXXX |
-| `0x08` | `invalid_message`             | {{basic-definitions}} of RFX XXXX |
-| `0x09` | `report_too_early`            | {{basic-definitions}} of RFX XXXX |
-| `0x0C` | `unknown_verification_key_id` | {{basic-definitions}} of RFC XXXX |
+| `0x07` | `invalid_message`             | {{basic-definitions}} of RFX XXXX |
+| `0x08` | `report_too_early`            | {{basic-definitions}} of RFX XXXX |
+| `0x09` | `unknown_verification_key_id` | {{basic-definitions}} of RFC XXXX |
 {: #report-error-id title="Initial contents of the DAP Report Error Identifiers
 registry."}
 

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1339,10 +1339,8 @@ enum {
   hpke_unknown_config_id(4),
   hpke_decrypt_error(5),
   vdaf_verify_error(6),
-  task_expired(7),
   invalid_message(8),
   report_too_early(9),
-  task_not_started(10),
   unknown_verification_key_id(12),
   (255)
 } ReportError;
@@ -1891,8 +1889,9 @@ The Leader MUST discard any report pertaining to a batch that has already been
 collected (see {{replay-protection}} for details). The Leader MAY also set the
 corresponding error field to `report_replayed`.
 
-The Leader MUST discard any report whose timestamp is outside of the task's
-`time_interval`. When it does so, it SHOULD set the corresponding error field to
+If the Task Interval Task Extension ({{task-interval-extension}}) is in use,
+then the Leader MUST discard any report whose timestamp is outside of the
+`task_interval`. When it does so, it SHOULD set the corresponding error field to
 `report_dropped`.
 
 The Leader may need to buffer reports while waiting to aggregate them (e.g.,
@@ -2650,15 +2649,10 @@ input share in the job, in any order:
    current time. If so, then the Aggregator SHOULD mark the input share as
    invalid with error `report_too_early`.
 
-1. If the `task_interval` task extension ({{task-interval-extension}}) is configured,
-   check if the report's timestamp is before the task's `task_interval`. If so,
-   the Aggregator MUST mark the input share as invalid with the error
-   `task_not_started`.
-
-1. If the `task_interval` task extension ({{task-interval-extension}}) is configured,
-   check if the report's timestamp is after the task's `task_interval`. If so,
-   the Aggregator MUST mark the input share as invalid with the error
-   `task_expired`.
+1. If the `task_interval` task extension ({{task-interval-extension}}) is
+   configured, check if the report's timestamp is outside the task's
+   `task_interval`. If so, the Aggregator MUST mark the input share as invalid
+   with the error `report_dropped`.
 
 1. Check if the public or private report extensions contain any unrecognized
    report extension types. If so, the Aggregator MUST mark the input share as
@@ -4904,10 +4898,8 @@ The initial contents of this registry are listed below in {{report-error-id}}.
 | `0x04` | `hpke_unknown_config_id`      | {{basic-definitions}} of RFX XXXX |
 | `0x05` | `hpke_decrypt_error`          | {{basic-definitions}} of RFX XXXX |
 | `0x06` | `vdaf_verify_error`           | {{basic-definitions}} of RFX XXXX |
-| `0x07` | `task_expired`                | {{basic-definitions}} of RFX XXXX |
 | `0x08` | `invalid_message`             | {{basic-definitions}} of RFX XXXX |
 | `0x09` | `report_too_early`            | {{basic-definitions}} of RFX XXXX |
-| `0x0A` | `task_not_started`            | {{basic-definitions}} of RFX XXXX |
 | `0x0C` | `unknown_verification_key_id` | {{basic-definitions}} of RFC XXXX |
 {: #report-error-id title="Initial contents of the DAP Report Error Identifiers
 registry."}

--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -182,11 +182,16 @@ aggregator.
 
 (RFC EDITOR: Remove this section.)
 
+19:
+
+- Delete unused or redundant `ReportError` variants. (\*) (#786)
+
+- Define explicit `unknown_verification_key_id` error. (\*) (#784)
 
 18:
 
 - Add verification key ID to aggregation jobs to enable but not require
-  verification key management. (\*) (#766, #784)
+  verification key management. (\*) (#766)
 
 - Define collection job extensions. (\*) (#769)
 


### PR DESCRIPTION
See individual commits for detailed discussion. The headline changes:

- Delete `ReportError::task_expired, task_not_started` and use `report_dropped` instead
- Delete `outdated_config` and use `hpke_unknown_config_id` instead

What's most likely to be controversional here is whether we still want specific `ReportError` values for when the task interval extension is in use and the report timestamp is outside of it.

My position is: no, `report_dropped` suffices. My argument is: if the Task Interval extension is configured, then the Client has to have agreed to its parameters because it gets included in the `TaskConfiguration` and then HPKE AADs. That means that before it ever uploads, the Client can assure itself that its report timestamp is inside the task's time interval, and thus we don't need a recovery mechanism that would nudge the Client into waiting until the task starts to upload.

Closes #785 