### PR TITLE
Allow task_info to be empty

### DIFF
--- a/draft-ietf-ppm-dap.md
+++ b/draft-ietf-ppm-dap.md
@@ -1464,7 +1464,7 @@ by a `TaskConfiguration` structure:
 uint32 VdafType;
 
 struct {
-    opaque task_info<1..2^8-1>;
+    opaque task_info<0..2^8-1>;
     Url leader_aggregator_endpoint;
     Url helper_aggregator_endpoint;
     TimePrecision time_precision;


### PR DESCRIPTION
While implementing DAP draft-18, we noticed that the `task_info` field of `TaskConfiguration` has a minimum length of 1. When this was part of the Taskprov draft, this made sense, because distinct `task_info` fields would be the only way to produce distinct task IDs for similar measurement tasks. In the context of DAP draft-18, `TaskConfiguration` gets included in `InputShareAad` and `AggregateShareAad` alongside the task ID, so `TaskConfiguration` does not need to be unique in all deployment scenarios. If unique `task_info` values are not needed because task IDs are chosen uniformly at random, then it would be nice if we could set `task_info` to the empty string as a sensible default.

In the context of Taskprov, the editor's copy suggests including entropy in `task_info` in order to defend against task enumeration attacks. If we take this DAP change, we could change Taskprov to require that `task_info` be non-empty. We may want stronger language pointing out that the whole `TaskConfiguration` struct needs to be unique in order to distinguish semantically different measurement tasks, and that `task_info` is the one place operators can stick enough entropy to achieve that uniqueness, when all other parameters are the same.